### PR TITLE
Display 'Ext' instead of 'Ext3' for `ext` SRs

### DIFF
--- a/XSConsoleLangFriendlyNames.py
+++ b/XSConsoleLangFriendlyNames.py
@@ -599,7 +599,7 @@ class LangFriendlyNames:
     'Label-SR.SRTypes-egenera' : 'Egenera Virtual Storage',
     'Label-SR.SRTypes-egeneracd' : 'Egenera Virtual DVD Drive',
     'Label-SR.SRTypes-equal' : 'Dell EqualLogic',
-    'Label-SR.SRTypes-ext' : 'Ext3',
+    'Label-SR.SRTypes-ext' : 'Ext',
     'Label-SR.SRTypes-iso' : 'ISO',
     'Label-SR.SRTypes-local' : 'Local',
     'Label-SR.SRTypes-lvm' : 'LVM',


### PR DESCRIPTION
Since the `ext` driver now defaults to EXT4, update the displayed type
for this kind of SR. Displaying 'Ext4' would be wrong in situations
where the SR was created before the default changed, so we simply remove
the digit and make it just 'Ext'.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>