### PR TITLE
LocalShell: display /etc/motd.xs, not empty /etc/motd

### DIFF
--- a/plugins-base/XSFeatureLocalShell.py
+++ b/plugins-base/XSFeatureLocalShell.py
@@ -32,7 +32,7 @@ class XSFeatureLocalShell:
         user = os.environ.get('USER', 'root')
         Layout.Inst().ExitBannerSet(Lang("\rShell for local user '")+user+"'.\r\r"+
                 Lang("Type 'exit' to return to the management console.\r"))
-        Layout.Inst().SubshellCommandSet("( export HOME=/root; export TMOUT="+str(State.Inst().AuthTimeoutSeconds())+" && cat /etc/motd && /bin/bash --login )")
+        Layout.Inst().SubshellCommandSet("( export HOME=/root; export TMOUT="+str(State.Inst().AuthTimeoutSeconds())+" && cat /etc/motd.xs && /bin/bash --login )")
         XSLog('Local shell')
         
     @classmethod


### PR DESCRIPTION
xsconsole today when starting a local shell displays the contents of the standard `/etc/motd` file.  OTOH, an installed XenServer or XCP-ng ships `/etc/motd` empty, and instead puts a warning for the user about to login as root that he has super powers and the responsibilities that goes with them, in `/etc/motd.xs`, and gets `login` to use it through `/etc/login.defs`.

If this `motd.xs` is here to stay, xsconsole likely means to display that one.