### PR TITLE
Keymaps moved to /lib/kbd/keymaps/legacy/i386

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -786,7 +786,7 @@ class Data:
             'keymaps' : {}
         }
 
-        keymapsPath = '/lib/kbd/keymaps/i386'
+        keymapsPath = '/lib/kbd/keymaps/legacy/i386'
         excludeExp = re.compile(re.escape(keymapsPath)+r'/include')
 
         filterExp = re.compile(r'(.*).map.gz$')


### PR DESCRIPTION
Since the Dom0 move to Centos7 the keymaps i386 directory was moved to the `/lib/kbd/keymaps/legacy` directory
This change fixes the xsconsole warnings of missing keymaps (as it was looking in the wrong place)
```
[root@lcy2-dt73 ~]# ls /lib/kbd/keymaps/
legacy  xkb
[root@lcy2-dt73 ~]# ls /lib/kbd/keymaps/legacy/
amiga  atari  i386  include  mac  ppc  sun
```