### PR TITLE
CA-369899: Improved NTP interface and behaviour

### DIFF
--- a/XSConsoleDialoguePane.py
+++ b/XSConsoleDialoguePane.py
@@ -190,10 +190,10 @@ class DialoguePane:
         self.AddBodyFieldObj(TextField(str(inName), self.brightColour, Field.FLOW_RIGHT))
         self.AddBodyFieldObj(WrappedTextField(str(inValue), self.baseColour, Field.FLOW_RETURN))
 
-    def AddInputField(self, inName, inValue, inLabel, inLengthLimit = None):
+    def AddInputField(self, inName, inValue, inLabel, inLengthLimit = None, inputWidth=INPUT_FIELD_DEFAULT_WIDTH, flow=Field.FLOW_RETURN):
         self.AddBodyFieldObj(TextField(str(inName), self.brightColour, Field.FLOW_RIGHT))
         self.AddInputFieldObj(InputField(str(inValue), self.highlightColour, self.selectedColour,
-            Field.FLOW_RETURN, inLengthLimit), inLabel)
+            flow, inLengthLimit, width=inputWidth), inLabel)
 
     def AddPasswordField(self, inName, inValue, inLabel, inLengthLimit = None):
         self.AddBodyFieldObj(TextField(str(inName), self.brightColour, Field.FLOW_RIGHT))

--- a/XSConsoleFields.py
+++ b/XSConsoleFields.py
@@ -44,17 +44,18 @@ class SeparatorField(Field):
     def Height(self):
         return 1
 
+INPUT_FIELD_DEFAULT_WIDTH = 40  # Declared for use in constructor
 class InputField(Field):
-    MIN_WIDTH = 40 # Minimum width for input fields
+    MIN_WIDTH = 5  # Minimum width for input fields
 
-    def __init__(self, text, colour, selectedColour, flow, lengthLimit):
+    def __init__(self, text, colour, selectedColour, flow, lengthLimit, width=INPUT_FIELD_DEFAULT_WIDTH):
         ParamsToAttr()
         self.activated = False
         self.cursorPos = len(self.text)
         self.hideText = False
         self.selected = True
         self.scrollPos = 0
-        self.width = self.MIN_WIDTH
+        self.UpdateWidth(width)
         if self.lengthLimit is None:
             self.lengthLimit = 4096
 

--- a/plugins-base/XSFeatureInterface.py
+++ b/plugins-base/XSFeatureInterface.py
@@ -419,11 +419,15 @@ class InterfaceDialogue(Dialogue):
         if self.nic is None:
             self.mode = None
             data.DisableManagement()
+            data.AdjustNTPForStaticNetwork()
+            Layout.Inst().PushDialogue(InfoDialogue(Lang("Removed DHCP NTP server")))
         else:
             pif = data.host.PIFs()[self.nic]
             if self.mode.lower().startswith('static'):
                 # Comma-separated list of nameserver IPs
                 dns = ','.join(data.dns.nameservers([]))
+                data.AdjustNTPForStaticNetwork()
+                Layout.Inst().PushDialogue(InfoDialogue(Lang("Removed DHCP NTP server")))
             else:
                 dns = ''
 

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -16,85 +16,243 @@
 if __name__ == "__main__":
     raise Exception("This script is a plugin for xsconsole and cannot run independently")
 
+import datetime
+
+
 from XSConsoleStandard import *
+from XSConsoleFields import Field
+
 
 class NTPDialogue(Dialogue):
     def __init__(self):
         Dialogue.__init__(self)
+        self.ChangeState("INITIAL")
 
-        data=Data.Inst()
-
+    def CreateINITIALPane(self):
         choiceDefs = [
-            ChoiceDef(Lang("Enable NTP Time Synchronization"), lambda: self.HandleInitialChoice('ENABLE') ),
-            ChoiceDef(Lang("Disable NTP Time Synchronization"), lambda: self.HandleInitialChoice('DISABLE') ),
-            ChoiceDef(Lang("Add an NTP Server"), lambda: self.HandleInitialChoice('ADD') ) ]
+            ChoiceDef(Lang("Use Default NTP Servers"), lambda: self.HandleInitialChoice('DEFAULT') ),
+            ChoiceDef(Lang("Provide NTP Servers Manually"), lambda: self.HandleInitialChoice('MANUAL') ),
+            ChoiceDef(Lang("Disable NTP (Manual Time Entry)"), lambda: self.HandleInitialChoice('NONE') )
+        ]
 
-        if len(data.ntp.servers([])) > 0:
-            choiceDefs.append(ChoiceDef(Lang("Remove a Single NTP Server"), lambda: self.HandleInitialChoice('REMOVE') ))
-            choiceDefs.append(ChoiceDef(Lang("Remove All NTP Servers"), lambda: self.HandleInitialChoice('REMOVEALL') ))
+        data = Data.Inst()
+        pifs = data.derived.managementpifs([])
+        usingDHCP = any("dhcp" in pif['ip_configuration_mode'].lower() for pif in pifs)
+        if usingDHCP:
+            choiceDefs.insert(0, ChoiceDef(Lang("Use DHCP NTP Servers"), lambda: self.HandleInitialChoice('DHCP')))
 
         if Auth.Inst().IsTestMode():
             # Show Status is a testing-only function
             choiceDefs.append(ChoiceDef(Lang("Show Status (ntpstat)"), lambda: self.HandleInitialChoice('STATUS') ))
 
-        self.ntpMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
+        self.initialMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
-        self.ChangeState('INITIAL')
+    def CreateMANUALPane(self):
+        choiceDefs = [
+            ChoiceDef(Lang("Add New Server"), lambda: self.HandleManualChoice("ADD"))
+        ]
+
+        data = Data.Inst()
+        data.UpdateFromNTPConf()
+
+        servers = data.ntp.servers([])
+        if data.ntp.method("") == "Manual" and len(servers) > 0:
+            choiceDefs.append(ChoiceDef(Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")))
+            choiceDefs.append(ChoiceDef(Lang("Remove All Servers"), lambda: self.HandleManualChoice("REMOVEALL")))
+
+        self.manualMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
+
+    def ChangeState(self, state):
+        self.state = state
+        self.BuildPane()
 
     def BuildPane(self):
-        if self.state == 'REMOVE':
-            choiceDefs = []
-            for server in Data.Inst().ntp.servers([]):
-                choiceDefs.append(ChoiceDef(server, lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex())))
-
-            self.removeMenu = Menu(self, None, Lang("Remove NTP Server"), choiceDefs)
-
         pane = self.NewPane(DialoguePane(self.parent))
         pane.TitleSet(Lang("Configure Network Time"))
         pane.AddBox()
         self.UpdateFields()
+
+    def UpdateFields(self):
+        self.Pane().ResetPosition()
+        getattr(self, 'UpdateFields'+self.state)() # Despatch method named 'UpdateFields'+self.state
 
     def UpdateFieldsINITIAL(self):
         pane = self.Pane()
         pane.ResetFields()
 
         pane.AddTitleField(Lang("Please Select an Option"))
-        pane.AddMenuField(self.ntpMenu)
+        self.CreateINITIALPane()
+        pane.AddMenuField(self.initialMenu)
         pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+    def UpdateFieldsMANUAL(self):
+        pane = self.Pane()
+        pane.ResetFields()
+
+        pane.AddTitleField(Lang("Please Select an Option"))
+        self.CreateMANUALPane()
+        pane.AddMenuField(self.manualMenu)
+        pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+    def UpdateFieldsNONE(self):
+        now = datetime.datetime.now()
+
+        pane = self.Pane()
+        pane.ResetFields()
+
+        pane.TitleSet(Lang("Set Current Time"))
+        pane.AddTitleField(Lang("Please set the current (local) date and time"))
+        pane.NewLine()
+
+        pane.AddInputField(Lang("Year: "), str(now.year), "year", inLengthLimit=4, flow=Field.FLOW_RIGHT, inputWidth=5)
+        pane.AddInputField(Lang("Month: "), "{:02d}".format(now.month), "month", inLengthLimit=2, flow=Field.FLOW_RIGHT, inputWidth=5)
+        pane.AddInputField(Lang("Day: "), "{:02d}".format(now.day), "day", inLengthLimit=2, inputWidth=5)
+        pane.NewLine()
+
+        pane.AddInputField(Lang("Hour (24h): "), "{:02d}".format(now.hour), "hour", inLengthLimit=2, flow=Field.FLOW_RIGHT, inputWidth=5)
+        pane.AddInputField(Lang("Minute: "), "{:02d}".format(now.minute), "minute", inLengthLimit=2, inputWidth=5)
+
+        pane.AddKeyHelpField( { Lang("<Up/Down>") : Lang("Next/Prev"), Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+        if pane.CurrentInput is None:
+            pane.InputIndexSet(0)
 
     def UpdateFieldsADD(self):
         pane = self.Pane()
         pane.ResetFields()
 
-        pane.AddTitleField(Lang("Please Enter the NTP Server Name or Address"))
-        pane.AddWrappedTextField(Lang("NTP servers supplied by DHCP may overwrite values configured here."))
+        pane.AddTitleField(Lang("Please Enter the NTP Server Name(s) or Address(es)"))
         pane.NewLine()
         pane.AddInputField(Lang("Server", 16), '', 'name')
+
         pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK") , Lang("<Esc>") : Lang("Cancel") } )
         if pane.CurrentInput() is None:
             pane.InputIndexSet(0)
 
     def UpdateFieldsREMOVE(self):
-        pane = self.Pane()
-        pane.ResetFields()
+        choiceDefs = []
+        for server in Data.Inst().ntp.servers([]):
+            choiceDefs.append(ChoiceDef(server, lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex())))
 
-        pane.AddTitleField(Lang("Select Server Entry to Remove"))
-        pane.AddWrappedTextField(Lang("NTP servers supplied by DHCP may overwrite values configured here."))
-        pane.NewLine()
+        self.removeMenu = Menu(self, None, Lang("Remove NTP Server"), choiceDefs)
 
-        pane.AddMenuField(self.removeMenu)
-        pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+    def HandleInitialChoice(self, inChoice):
+        data = Data.Inst()
+        try:
+            if inChoice == "DHCP":
+                Layout.Inst().PopDialogue()
+                Layout.Inst().TransientBanner(Lang("Enabling DHCP NTP Server..."))
+                data.NTPServersSet([])
+                data.AddDHCPNTP()
+                self.Commit(Lang("DHCP NTP Time Synchronization Enabled"))
 
-    def UpdateFields(self):
-        self.Pane().ResetPosition()
-        getattr(self, 'UpdateFields'+self.state)() # Despatch method named 'UpdateFields'+self.state
+            elif inChoice == "DEFAULT":
+                Layout.Inst().PopDialogue()
+                Layout.Inst().TransientBanner(Lang("Enabling Default NTP Servers..."))
+                data.ResetDefaultNTPServers()
+                data.RemoveDHCPNTP()
+                self.Commit(Lang("Default NTP Time Synchronization Enabled"))
 
-    def ChangeState(self, inState):
-        self.state = inState
-        self.BuildPane()
+            elif inChoice == "MANUAL":
+                self.ChangeState("MANUAL")
+            elif inChoice == "NONE":
+                self.ChangeState("NONE")
+
+            elif inChoice == "STATUS":
+                message = data.NTPStatus()+Lang("\n\n(Initial synchronization may take several minutes)")
+                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Status"), message))
+
+        except Exception, e:
+            Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))
+
+        data.Update()
+
+    def HandleManualChoice(self, inChoice):
+        data = Data.Inst()
+        try:
+            if inChoice == "ADD":
+                self.ChangeState("ADD")
+            elif inChoice == "REMOVE":
+                self.ChangeState("REMOVE")
+            elif inChoice == "REMOVEALL":
+                Layout.Inst().PopDialogue()
+                data.NTPServersSet([])
+                self.Commit(Lang("All server entries deleted"))
+
+        except Exception, e:
+            Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))
+
+        data.Update()
+
+    def HandleRemoveChoice(self, inChoice):
+        Layout.Inst().PopDialogue()
+        data=Data.Inst()
+        servers = data.ntp.servers([])
+        thisServer = servers[inChoice]
+        del servers[inChoice]
+        data.NTPServersSet(servers)
+        self.Commit(Lang("NTP server")+" "+thisServer+" "+Lang("deleted"))
+        data.Update()
+
+    def HandleKey(self,  inKey): # Route any menu key presses to the currentl state handler
+        handled = False
+        if hasattr(self, 'HandleKey'+self.state):
+            handled = getattr(self, 'HandleKey'+self.state)(inKey)
+
+        if not handled and inKey == 'KEY_ESCAPE':
+            Layout.Inst().PopDialogue()
+            handled = True
+
+        return handled
 
     def HandleKeyINITIAL(self, inKey):
-        return self.ntpMenu.HandleKey(inKey)
+        return self.initialMenu.HandleKey(inKey)
+
+    def HandleKeyMANUAL(self, inKey):
+        return self.manualMenu.HandleKey(inKey)
+
+    def HandleKeyNONE(self, inKey):
+        handled = True
+        pane = self.Pane()
+        if pane.CurrentInput() is None:
+            pane.InputIndexSet(0)
+
+        if inKey == 'KEY_ENTER':
+            inputValues = pane.GetFieldValues()
+            Layout.Inst().PopDialogue()
+
+            try:
+                year = inputValues["year"].strip()
+                month = inputValues["month"].strip()
+                day = inputValues["day"].strip()
+                hour = inputValues["hour"].strip()
+                minute = inputValues["minute"].strip()
+
+                date_string = "%04d-%02d-%02d %02d:%02d:00" % (int(year), int(month), int(day), int(hour), int(minute))
+                date_format = "%Y-%m-%d %H:%M:00"
+                date = datetime.datetime.strptime(date_string, date_format)
+
+                data = Data.Inst()
+                data.RemoveDHCPNTP()
+                data.SetTimeManually(date)
+
+                self.Commit(Lang("Time Set Manually"), restartChronyd=False)
+            except Exception, e:
+                Layout.Inst().PushDialogue(InfoDialogue(Lang(e)))
+
+        elif inKey == 'KEY_DOWN':
+            newIndex = (pane.InputIndex() + 1) % pane.fieldGroup.NumInputFields()
+            pane.InputIndexSet(newIndex)
+        elif inKey == 'KEY_UP':
+            newIndex = (pane.InputIndex() - 1) % pane.fieldGroup.NumInputFields()
+            pane.InputIndexSet(newIndex)
+
+        elif pane.CurrentInput().HandleKey(inKey):
+            pass
+        else:
+            handled = False
+
+        return handled
 
     def HandleKeyADD(self, inKey):
         handled = True
@@ -106,13 +264,20 @@ class NTPDialogue(Dialogue):
             Layout.Inst().PopDialogue()
             try:
                 IPUtils.AssertValidNetworkName(inputValues['name'])
+
                 data=Data.Inst()
+                if data.ntp.method("") == "Default":
+                    data.NTPServersSet([server for server in data.ntp.servers([]) if "centos.pool.ntp.org" not in server])
+
+                data.RemoveDHCPNTP()
+
                 servers = data.ntp.servers([])
                 servers.append(inputValues['name'])
                 data.NTPServersSet(servers)
                 self.Commit(Lang("NTP server")+" "+inputValues['name']+" "+Lang("added"))
             except Exception, e:
                 Layout.Inst().PushDialogue(InfoDialogue(Lang(e)))
+
         elif pane.CurrentInput().HandleKey(inKey):
             pass # Leave handled as True
         else:
@@ -122,64 +287,11 @@ class NTPDialogue(Dialogue):
     def HandleKeyREMOVE(self, inKey):
         return self.removeMenu.HandleKey(inKey)
 
-    def HandleKey(self,  inKey):
-        handled = False
-        if hasattr(self, 'HandleKey'+self.state):
-            handled = getattr(self, 'HandleKey'+self.state)(inKey)
-
-        if not handled and inKey == 'KEY_ESCAPE':
-            Layout.Inst().PopDialogue()
-            handled = True
-
-        return handled
-
-    def HandleInitialChoice(self,  inChoice):
-        data = Data.Inst()
-        try:
-            if inChoice == 'ENABLE':
-                Layout.Inst().TransientBanner(Lang("Enabling..."))
-                data.EnableService('chronyd')
-                data.EnableService('chrony-wait')
-                data.StartService('chronyd')
-                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Time Synchronization Enabled")))
-            elif inChoice == 'DISABLE':
-                Layout.Inst().TransientBanner(Lang("Disabling..."))
-                data.DisableService('chronyd')
-                data.DisableService('chrony-wait')
-                data.StopService('chronyd')
-                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Time Synchronization Disabled")))
-            elif inChoice == 'ADD':
-                self.ChangeState('ADD')
-            elif inChoice == 'REMOVE':
-                self.ChangeState('REMOVE')
-            elif inChoice == 'REMOVEALL':
-                Layout.Inst().PopDialogue()
-                data.NTPServersSet([])
-                self.Commit(Lang("All server entries deleted"))
-            elif inChoice == 'STATUS':
-                message = data.NTPStatus()+Lang("\n\n(Initial synchronization may take several minutes)")
-                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Status"), message))
-
-        except Exception, e:
-            Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))
-
-        data.Update()
-
-    def HandleRemoveChoice(self,  inChoice):
-        Layout.Inst().PopDialogue()
-        data=Data.Inst()
-        servers = data.ntp.servers([])
-        thisServer = servers[inChoice]
-        del servers[inChoice]
-        data.NTPServersSet(servers)
-        self.Commit(Lang("NTP server")+" "+thisServer+" "+Lang("deleted"))
-        data.Update()
-
-    def Commit(self, inMessage):
+    def Commit(self, inMessage, restartChronyd=True):
         data=Data.Inst()
         try:
             data.SaveToNTPConf()
-            if data.chkconfig.chronyd(False):
+            if restartChronyd:
                 Layout.Inst().TransientBanner(Lang("Restarting NTP daemon with new configuration..."))
                 data.RestartService('chronyd')
             Layout.Inst().PushDialogue(InfoDialogue( inMessage))
@@ -188,28 +300,39 @@ class NTPDialogue(Dialogue):
 
         data.Update()
 
+
 class XSFeatureNTP:
     @classmethod
     def StatusUpdateHandler(cls, inPane):
         data = Data.Inst()
+        data.UpdateFromNTPConf()
+
         inPane.AddTitleField(Lang("Network Time (NTP)"))
 
         inPane.AddWrappedTextField(Lang("One or more network time servers can be configured to synchronize time between servers.  This is especially important for pooled servers."))
         inPane.NewLine()
 
-        if not data.chkconfig.chronyd(False):
-            inPane.AddWrappedTextField(Lang("Currently NTP is disabled, and the following servers are configured."))
+        ntpMethod = data.ntp.method("<Unknown>")
+        if ntpMethod == "Disabled":
+            inPane.AddWrappedTextField(Lang("Currently NTP is disabled."))
         else:
             inPane.AddWrappedTextField(Lang("Currently NTP is enabled, and the following servers are configured."))
 
-        inPane.NewLine()
+            servers = data.ntp.servers([])
+            if ntpMethod == "DHCP":
+                gateway = data.ManagementGateway()
+                if gateway is None:
+                    gateway = "Refreshing..."
 
-        servers = data.ntp.servers([])
-        if len(servers) == 0:
-            inPane.AddWrappedTextField(Lang("<No servers configured>"))
-        else:
-            for server in servers:
-                inPane.AddWrappedTextField(server)
+                servers = [Lang(str(gateway) + " (DHCP)")]
+
+            inPane.NewLine()
+
+            if len(servers) == 0:
+                inPane.AddWrappedTextField(Lang("<No servers configured>"))
+            else:
+                for server in servers:
+                    inPane.AddWrappedTextField(server)
 
         inPane.AddKeyHelpField( {
             Lang("<Enter>") : Lang("Reconfigure"),

--- a/plugins-base/XSMenuLayout.py
+++ b/plugins-base/XSMenuLayout.py
@@ -52,7 +52,8 @@ class XSMenuLayout:
 
     def UpdateFieldsNETWORK(self, inPane):
         data = Data.Inst()
-        
+        data.UpdateFromNTPConf()
+
         inPane.AddTitleField(Lang("Network and Management Interface"))
         
         inPane.AddWrappedTextField(Lang("Press <Enter> to configure the management network connection, hostname, and network time (NTP) settings."))
@@ -62,10 +63,6 @@ class XSMenuLayout:
             inPane.AddWrappedTextField(Lang("Currently, no management interface is configured."))
         else:
             inPane.AddTitleField(Lang("Current Management Interface"))
-            if data.chkconfig.chronyd(False):
-                ntpState = 'Enabled'
-            else:
-                ntpState = 'Disabled'
             
             for pif in data.derived.managementpifs([]):
                 inPane.AddStatusField(Lang('Device', 16), pif['device'])
@@ -76,7 +73,8 @@ class XSMenuLayout:
                 inPane.AddStatusField(Lang('Netmask', 16),  data.ManagementNetmask(''))
                 inPane.AddStatusField(Lang('Gateway', 16),  data.ManagementGateway(''))
                 inPane.AddStatusField(Lang('Hostname', 16),  data.host.hostname(''))
-                inPane.AddStatusField(Lang('NTP', 16),  ntpState)
+
+                inPane.AddStatusField(Lang('NTP', 16),  data.ntp.method(''))
 
         inPane.AddKeyHelpField( { Lang("<F5>") : Lang("Refresh")})
             


### PR DESCRIPTION
Reflects behaviour defined in host-installer: https://github.com/xenserver/host-installer/commit/e7f4c5abbf149de9c42d984b627573425812ad6a

This grants more accurate control over the NTP servers used and whether to use the DHCP NTP server (if available), it also reset NTP settings in the event that DHCP is disabled or changed to static networking.

A side effect is that changing the time manually into the past and then settings NTP servers results in the console correctly updating and immediately presenting the user with a "press any key to wake" dialogue, this is captured in an internal ticket and will be addressed as part of the python2to3 upgrade for xsconsole