### PR TITLE
Fix PR#17 commit 'misc changes', it broke listing and editing Storage Repositories

### DIFF
--- a/XSConsoleHotData.py
+++ b/XSConsoleHotData.py
@@ -69,14 +69,18 @@ class HotAccessor:
             raise Exception(Lang("Cannot iterate over type '")+str(type(iterData))+"'")
         return self
 
-    # This method will hide fields called 'next' in the xapi database.  If any appear, __iter__ will need to
-    # return a new object type and this method will need to be moved into that
+    # This method will hide fields called '__next__' in the xapi database.
+    # If any appear, __iter__ will need to return a new object type
+    # and this method will need to be moved into that:
     def __next__(self):
         if len(self.iterKeys) <= 0:
             raise StopIteration
         retVal = HotAccessor(self.name[:], self.refs[:]) # [:] copies the array
         retVal.refs[-1] = self.iterKeys.pop(0)
         return retVal
+
+    if sys.version_info < (3, 0):
+        next = __next__  # Python2 iterator calls next() to get the next item.
 
     def __getitem__(self, inParam):
         # These are square brackets selecting a particular item from a dict using its OpaqueRef


### PR DESCRIPTION
Fix this regression which was introduced by #17, commit 5: "Misc changes":

https://github.com/xapi-project/xsconsole/pull/17/commits/29b179366062f20587de3812e80c0a7567298122#diff-7a99a3d0d9dc721b20052fba067d76350ea7734d0f26607afec287ad0a296f7c

In https://github.com/xapi-project/xsconsole/pull/18#issuecomment-1791844449, Andrew said that breaking the Python2 master branch before the Python3 branch works is not and option, therefore fix this first.

![SRs-list-edit-broken](https://github.com/xapi-project/xsconsole/assets/43588962/180b794d-f9b5-48f7-af35-c2b7ba36c791)

With Python3, after all commits from #20 are also applied, XSConsole still says:

![Screenshot-no-SRs-Py3](https://github.com/xapi-project/xsconsole/assets/43588962/bb550449-5b56-42fa-bca7-cdb82805f15b)

Therfore, the situation is clear: Fix Python2 first.