### PR TITLE
Remove the use of __cmp__ and use __eq__ instead

### DIFF
--- a/XSConsoleHotData.py
+++ b/XSConsoleHotData.py
@@ -32,18 +32,16 @@ class HotOpaqueRef:
     def __repr__(self):
         return str(self.__dict__)
 
-    # __hash__ and __cmp__ allow this object to be used as a dictionary key
+    # __hash__ and __eq__ allow this object to be used as a dictionary key
     def __hash__(self):
         return self.hash
 
-    def __cmp__(self, inOther):
+    def __eq__(self, inOther):
         if not isinstance(inOther, HotOpaqueRef):
-            return 1
+            return False
         if self.opaqueRef == inOther.opaqueRef:
-            return 0
-        if self.opaqueRef < inOther.opaqueRef:
-            return -1
-        return 1
+            return True
+        return False
 
     def OpaqueRef(self): return self.opaqueRef
     def Type(self): return self.type


### PR DESCRIPTION
According to the agreement with Andrew at https://github.com/xapi-project/xsconsole/pull/18#issuecomment-1791844449, Python2-compatible changes can go to the master branch freely, before branching of the Python3-only changes into a py3 branch:

> So, please can we collect together all commits which are py2-safe fixes, which can get reviewed and merged freely, and please keep all commits which break compatibility with py2 in a separate single PR so it can be merged all in one go. The final commit on the py3 branch should bump the major version number of xsconsole seeing as its a bit step change.

Qin Zhang （张琴）authored this commit and I reviewed it:
- The `__hash__` function (needed in addition to __eq__ for Python3's datamodel) is already in the code, so this change is fine for Py2 and Py3