### PR TITLE
Update/Fixup string encoding to for Python3 while not breaking Python2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,6 @@ jobs:
 
           # FIXME/TODO: These checks by pylint --py3k are currently failing:
           py3_todo: "\
-            unicode-builtin,\
             comprehension-escape,\
             dict-keys-not-iterating,\
             old-division"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Join the XSConsole community by creating issues in the repository to report bugs
 - **As per this agreement**, until that point, changes supporting **only Python3.6+** must go to a **py3 feature branch**.
 - The list of `TODOs` remaining for the Python3 upgrade checks (`pylint --py3k`) to be fulfilled is at [line 40 of `.github/workflows/main.yml`](https://github.com/xenserver-next/xsconsole/blob/master/.github/workflows/main.yml#L40).
   Currently, the list of `pylint --py3k` `TODOs` is:
-  - `unicode-builtin` (a PR using a function for Py2 and Py3 is working and is coming next)
   - `comprehension-escape`
   - `dict-keys-not-iterating`
   - `old-division`

--- a/XSConsoleCurses.py
+++ b/XSConsoleCurses.py
@@ -279,10 +279,10 @@ class CursesPane:
             retVal.append(self.title)
         if self.hasBox:
             for i in range(1, self.ySize - 1):
-                retVal.append(self.win.instr(i, 1, self.xSize - 2).decode('utf-8'))
+                retVal.append(convert_anything_to_str(self.win.instr(i, 1, self.xSize - 2)))  # instr() -> bytes -> str
         else:
             for i in range(self.ySize):
-                retVal.append(self.win.instr(i, 0, self.xSize).decode('utf-8'))
+                retVal.append(convert_anything_to_str(self.win.instr(i, 0, self.xSize)))  # win.instr() -> bytes -> str
 
         return retVal
 

--- a/XSConsoleCurses.py
+++ b/XSConsoleCurses.py
@@ -174,8 +174,8 @@ class CursesPane:
             if len(clippedStr) > 0:
                 try:
                     encodedStr = clippedStr
-                    if isinstance(clippedStr, unicode):
-                        encodedStr = clippedStr.encode('utf-8')
+                    if isinstance(clippedStr, bytes):
+                        encodedStr = clippedStr.decode('utf-8')
                         # Clear field here since addstr will clear len(encodedStr)-len(clippedStr) too few spaces
                         self.win.addstr(inY, xPos, len(clippedStr)*' ', CursesPalette.ColourAttr(FirstValue(inColour, self.defaultColour)))
                         self.win.refresh()

--- a/XSConsoleCurses.py
+++ b/XSConsoleCurses.py
@@ -174,8 +174,8 @@ class CursesPane:
             if len(clippedStr) > 0:
                 try:
                     encodedStr = clippedStr
-                    if isinstance(clippedStr, bytes):
-                        encodedStr = clippedStr.decode('utf-8')
+                    if not isinstance(clippedStr, str):
+                        encodedStr = convert_anything_to_str(clippedStr)
                         # Clear field here since addstr will clear len(encodedStr)-len(clippedStr) too few spaces
                         self.win.addstr(inY, xPos, len(clippedStr)*' ', CursesPalette.ColourAttr(FirstValue(inColour, self.defaultColour)))
                         self.win.refresh()

--- a/XSConsoleCurses.py
+++ b/XSConsoleCurses.py
@@ -278,11 +278,11 @@ class CursesPane:
         if self.title != "":
             retVal.append(self.title)
         if self.hasBox:
-            for i in range(1, self.ySize-1):
-                retVal.append(self.win.instr(i, 1, self.xSize-2))
+            for i in range(1, self.ySize - 1):
+                retVal.append(self.win.instr(i, 1, self.xSize - 2).decode('utf-8'))
         else:
             for i in range(self.ySize):
-                retVal.append(self.win.instr(i, 0, self.xSize))
+                retVal.append(self.win.instr(i, 0, self.xSize).decode('utf-8'))
 
         return retVal
 

--- a/XSConsoleLang.py
+++ b/XSConsoleLang.py
@@ -82,15 +82,15 @@ class Language:
         elif isinstance(inLabel, Exception):
             exn_strings = []
             for arg in inLabel.args:
-                if isinstance(arg, unicode):
-                    exn_strings.append(arg.encode('utf-8'))
+                if isinstance(arg, bytes):
+                    exn_strings.append(arg.decode('utf-8'))
                 else:
                     exn_strings.append(str(arg))
             retVal = str(tuple(exn_strings))
             cls.LogError(retVal)
         else:
-            if isinstance(inLabel, unicode):
-                inLabel = inLabel.encode('utf-8')
+            if isinstance(inLabel, bytes):
+                inLabel = inLabel.decode('utf-8')
             retVal = inLabel
             if cls.stringHook is not None:
                 cls.stringHook(retVal)

--- a/plugins-base/XSFeatureSRCommon.py
+++ b/plugins-base/XSFeatureSRCommon.py
@@ -211,7 +211,7 @@ class SRControlDialogue(Dialogue):
         pane.ResetFields()
 
         sr = HotAccessor().sr[self.srHandle]
-        srName = sr.name_label(None).encode('utf-8')
+        srName = sr.name_label(None)
         if srName is None:
             pane.AddTitleField(Lang("The Virtual Machine is no longer present"))
         else:
@@ -226,7 +226,7 @@ class SRControlDialogue(Dialogue):
         pane.ResetFields()
 
         sr = HotAccessor().sr[self.srHandle]
-        srName = sr.name_label(None).encode('utf-8')
+        srName = sr.name_label(None)
         if srName is None:
             pane.AddTitleField(Lang("The Storage Repository is no longer present"))
         else:
@@ -282,7 +282,7 @@ class SRControlDialogue(Dialogue):
         Layout.Inst().PopDialogue()
 
         operationName = SRUtils.OperationName(self.operation)
-        srName = HotAccessor().sr[self.srHandle].name_label(Lang('<Unknown>')).encode('utf-8')
+        srName = HotAccessor().sr[self.srHandle].name_label(Lang('<Unknown>'))
         messagePrefix = operationName + Lang(' operation on ') + srName + ' '
         Layout.Inst().TransientBanner(messagePrefix+Lang('in progress...'))
         try:

--- a/plugins-base/XSFeatureSRCommon.py
+++ b/plugins-base/XSFeatureSRCommon.py
@@ -211,7 +211,7 @@ class SRControlDialogue(Dialogue):
         pane.ResetFields()
 
         sr = HotAccessor().sr[self.srHandle]
-        srName = sr.name_label(None)
+        srName = convert_anything_to_str(sr.name_label(None))
         if srName is None:
             pane.AddTitleField(Lang("The Virtual Machine is no longer present"))
         else:
@@ -226,7 +226,7 @@ class SRControlDialogue(Dialogue):
         pane.ResetFields()
 
         sr = HotAccessor().sr[self.srHandle]
-        srName = sr.name_label(None)
+        srName = convert_anything_to_str(sr.name_label(None))
         if srName is None:
             pane.AddTitleField(Lang("The Storage Repository is no longer present"))
         else:
@@ -282,7 +282,7 @@ class SRControlDialogue(Dialogue):
         Layout.Inst().PopDialogue()
 
         operationName = SRUtils.OperationName(self.operation)
-        srName = HotAccessor().sr[self.srHandle].name_label(Lang('<Unknown>'))
+        srName = convert_anything_to_str(HotAccessor().sr[self.srHandle].name_label(Lang('<Unknown>')))
         messagePrefix = operationName + Lang(' operation on ') + srName + ' '
         Layout.Inst().TransientBanner(messagePrefix+Lang('in progress...'))
         try:

--- a/plugins-base/XSFeatureVMCommon.py
+++ b/plugins-base/XSFeatureVMCommon.py
@@ -169,7 +169,7 @@ class VMControlDialogue(Dialogue):
         pane.ResetFields()
 
         vm = HotAccessor().guest_vm[self.vmHandle]
-        vmName = vm.name_label(None)
+        vmName = convert_anything_to_str(vm.name_label(None))
         if vmName is None:
             pane.AddTitleField(Lang("The Virtual Machine is no longer present"))
         else:
@@ -190,7 +190,7 @@ class VMControlDialogue(Dialogue):
         pane.ResetFields()
 
         vm = HotAccessor().vm[self.vmHandle]
-        vmName = vm.name_label(None)
+        vmName = convert_anything_to_str(vm.name_label(None))
         if vmName is None:
             pane.AddTitleField(Lang("The Virtual Machine is no longer present"))
         else:
@@ -252,7 +252,7 @@ class VMControlDialogue(Dialogue):
         Layout.Inst().PopDialogue()
 
         operationName = VMUtils.OperationName(self.operation)
-        vmName = HotAccessor().guest_vm[self.vmHandle].name_label(Lang('<Unknown>'))
+        vmName = convert_anything_to_str(HotAccessor().guest_vm[self.vmHandle].name_label(Lang('<Unknown>')))
         messagePrefix = operationName + Lang(' operation on ') + vmName + ' '
         try:
             task = VMUtils.AsyncOperation(self.operation, self.vmHandle, *self.opParams)

--- a/plugins-base/XSFeatureVMCommon.py
+++ b/plugins-base/XSFeatureVMCommon.py
@@ -169,7 +169,7 @@ class VMControlDialogue(Dialogue):
         pane.ResetFields()
 
         vm = HotAccessor().guest_vm[self.vmHandle]
-        vmName = vm.name_label(None).encode('utf-8')
+        vmName = vm.name_label(None)
         if vmName is None:
             pane.AddTitleField(Lang("The Virtual Machine is no longer present"))
         else:
@@ -190,7 +190,7 @@ class VMControlDialogue(Dialogue):
         pane.ResetFields()
 
         vm = HotAccessor().vm[self.vmHandle]
-        vmName = vm.name_label(None).encode('utf-8')
+        vmName = vm.name_label(None)
         if vmName is None:
             pane.AddTitleField(Lang("The Virtual Machine is no longer present"))
         else:
@@ -252,7 +252,7 @@ class VMControlDialogue(Dialogue):
         Layout.Inst().PopDialogue()
 
         operationName = VMUtils.OperationName(self.operation)
-        vmName = HotAccessor().guest_vm[self.vmHandle].name_label(Lang('<Unknown>')).encode('utf-8')
+        vmName = HotAccessor().guest_vm[self.vmHandle].name_label(Lang('<Unknown>'))
         messagePrefix = operationName + Lang(' operation on ') + vmName + ' '
         try:
             task = VMUtils.AsyncOperation(self.operation, self.vmHandle, *self.opParams)


### PR DESCRIPTION
## Update/Fixup string encoding to for Python3 while not breaking Python2 

Tested as the first commit which keeps Python2 working, while have (seemingly) working Python3

Status: `pylint --py3k` has 3 TODOs left to fix, but this is the first version which works for Python3 as well! 🥇 

Use the `Files` tab for the review which squashes the commits, or just review commit 2 and commit 4 (links below):
-> Commit 2 and 4 fully override commit 1 and 3, so they cancel/replace commit 1 and 3.

#### Commit 1: [Remove the use of '`unicode`'](https://github.com/xapi-project/xsconsole/commit/58ba0d14f5e12f3b8b415e293e5e170749339dde)
#### Commit 2: Fixup commit 1: [Update commit "Remove the use of 'unicode'" to unbreak Python2](https://github.com/xapi-project/xsconsole/commit/05b27bede326257b901f08a4194f51ade70ea422)
#### Commit 3: [Py3-only: Change str encoding from Python2 to only support Python3](https://github.com/xapi-project/xsconsole/commit/d15d32b5ba86da76a157bfa6108982da70f04603)
#### Commit 4: Fixup commit 3: [Update commit Py3-only: Change str encoding to unbreak Python2](https://github.com/xapi-project/xsconsole/commit/0e456b0126cc4938365ceed1abb3404a8c4ce203)
#### Commit 5: [Remove 'unicode-builtin' from the pylint --py3k TODO list](https://github.com/xapi-project/xsconsole/commit/4943f34cbde554c31228568ff5dbd8e21c5f06ed)