### PR TITLE
Avoid useless processes launching shell

### DIFF
--- a/plugins-base/XSFeatureLocalShell.py
+++ b/plugins-base/XSFeatureLocalShell.py
@@ -32,7 +32,7 @@ class XSFeatureLocalShell:
         user = os.environ.get('USER', 'root')
         Layout.Inst().ExitBannerSet(Lang("\rShell for local user '")+user+"'.\r\r"+
                 Lang("Type 'exit' to return to the management console.\r"))
-        Layout.Inst().SubshellCommandSet("( export HOME=/root; export TMOUT="+str(State.Inst().AuthTimeoutSeconds())+" && cat /etc/motd && /bin/bash --login )")
+        Layout.Inst().SubshellCommandSet("cat /etc/motd && HOME=/root TMOUT="+str(State.Inst().AuthTimeoutSeconds())+" exec /bin/bash --login")
         XSLog('Local shell')
 
     @classmethod


### PR DESCRIPTION
There's no reason to keep 3 shell processes to execute one. Remove "()" in command to avoid one additional process. Add "exec" on last command to replace current process. Remove exports, not necessary as changing one single command environment.

This changes this:

```sh
$ pstree -alp | grep -4 bash
...
  |-python,2051 /usr/lib64/xsconsole/XSConsole.py -f root
  |   `-sh,3238 -c ( export HOME=/root; export TMOUT=300 && cat /etc/motd && /bin/bash --login )
  |       `-sh,3239 -c ( export HOME=/root; export TMOUT=300 && cat /etc/motd && /bin/bash --login )
  |           `-bash,3241 --login
...
```

to this:

```sh
$ pstree -alp | grep -4 bash
...
  |-python,2044 /usr/lib64/xsconsole/XSConsole.py -f root
  |   `-bash,3128 --login
...
```