### PR TITLE
[WIP] CP-47926: Preferred locale encoding should ignore case

### DIFF
--- a/XSConsoleCurses.py
+++ b/XSConsoleCurses.py
@@ -326,7 +326,7 @@ class CursesScreen(CursesPane):
         # Needed by python2-curses to support more of UTF-8 than just lower-case latin chars:
 
         preferred_charset_encoding_by_user = locale.getpreferredencoding()
-        if preferred_charset_encoding_by_user != "UTF-8":
+        if preferred_charset_encoding_by_user.upper() != "UTF-8":
             locale.setlocale(locale.LC_ALL, 'en_US')
         else:
             locale.setlocale(locale.LC_ALL, "")

--- a/XSConsoleMetrics.py
+++ b/XSConsoleMetrics.py
@@ -23,7 +23,7 @@ from XSConsoleLang import *
 if sys.version_info[0] == 2:
     # Python 2
     from urllib import URLopener
-    
+
     def urlopen(url):
        return URLopener().open(url)
 else:
@@ -107,7 +107,7 @@ class HotMetrics:
         xmlDoc = xml.dom.minidom.parseString(inXML)
         metaNode = xmlDoc.getElementsByTagName('meta')[0]
         valuesNode = xmlDoc.getElementsByTagName('data')[0]
-        
+
         meta = Struct()
         # Values comments out below are currently not required
         # for name in ('start', 'end', 'rows', 'columns'):


### PR DESCRIPTION
The `locale` module in python has different output for getpreferredencoding between python3.11 and python3.6
- 3.11: 'utf-8'
- 3.6: 'UTF-8'

The case of the return value should be ignored to match both