### PR TITLE
CA-369899: Add NTP options DHCP|Default|Manual|None

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SCRIPTS += XSConsole.py
 SCRIPTS += XSConsoleAuth.py
 SCRIPTS += XSConsoleBases.py
 SCRIPTS += XSConsoleConfig.py
+SCRIPTS += XSConsoleConstants.py
 SCRIPTS += XSConsoleCurses.py
 SCRIPTS += XSConsoleData.py
 SCRIPTS += XSConsoleDataUtils.py

--- a/XSConsoleAuth.py
+++ b/XSConsoleAuth.py
@@ -25,6 +25,13 @@ from XSConsoleUtils import *
 
 import XenAPI
 
+
+if sys.version_info >= (3, 0):
+    getTimeStamp = time.monotonic
+else:
+    getTimeStamp = time.time
+
+
 class Auth:
     instance = None
 
@@ -68,7 +75,7 @@ class Auth:
 
     def AuthAge(self):
         if self.isAuthenticated:
-            retVal = time.time() - self.authTimestampSeconds
+            retVal = getTimeStamp() - self.authTimestampSeconds
         else:
             raise Exception("Cannot get age - not authenticated")
         return retVal
@@ -77,7 +84,7 @@ class Auth:
         if self.isAuthenticated:
             if self.AuthAge() <= State.Inst().AuthTimeoutSeconds():
                 # Auth still valid, so update timestamp to now
-                self.authTimestampSeconds = time.time()
+                self.authTimestampSeconds = getTimeStamp()
 
     def LoggedInUsername(self):
         if (self.isAuthenticated):
@@ -126,7 +133,7 @@ class Auth:
         if self.testingHost is not None:
             # Store password when testing only
             self.loggedInPassword = inPassword
-        self.authTimestampSeconds = time.time()
+        self.authTimestampSeconds = getTimeStamp()
         self.isAuthenticated = True
         XSLog('User authenticated successfully')
 

--- a/XSConsoleConstants.py
+++ b/XSConsoleConstants.py
@@ -1,2 +1,7 @@
 # Default NTP domains are <int>.[centos|xenserver].pool.ntp.org
-DEFAULT_NTP_DOMAINS = [".centos.pool.ntp.org", ".xenserver.pool.ntp.org"]
+CENTOS_NTP_POOL_DOMAIN = "centos.pool.ntp.org"
+DEFAULT_NTP_DOMAINS = [CENTOS_NTP_POOL_DOMAIN, "xenserver.pool.ntp.org"]
+
+NUM_DEFAULT_NTP_SERVERS = 4
+
+DEFAULT_NTP_SERVERS = ["%d.%s" % (i, CENTOS_NTP_POOL_DOMAIN) for i in range(NUM_DEFAULT_NTP_SERVERS)]

--- a/XSConsoleConstants.py
+++ b/XSConsoleConstants.py
@@ -1,0 +1,2 @@
+# Default NTP domains are <int>.[centos|xenserver].pool.ntp.org
+DEFAULT_NTP_DOMAINS = [".centos.pool.ntp.org", ".xenserver.pool.ntp.org"]

--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -15,7 +15,8 @@
 
 import XenAPI
 import datetime
-import subprocess, re, shutil, sys, tempfile, socket, os
+import time
+import subprocess, re, shutil, sys, tempfile, socket, os, stat
 from pprint import pprint
 from simpleconfig import SimpleConfigFile
 
@@ -486,9 +487,25 @@ class Data:
             self.ScanHostname(output.split("\n"))
 
     def UpdateFromNTPConf(self):
+        if not 'ntp' in self.data:
+            self.data['ntp'] = {}
+
         (status, output) = getstatusoutput("/bin/cat /etc/chrony.conf")
         if status == 0:
             self.ScanNTPConf(output.split("\n"))
+
+        self.data['ntp']['method'] = ""
+        chronyPerm = os.stat("/etc/dhcp/dhclient.d/chrony.sh").st_mode
+        if chronyPerm & stat.S_IXUSR and chronyPerm & stat.S_IXGRP and chronyPerm & stat.S_IXOTH:
+            self.data['ntp']['method'] = "DHCP"
+        elif self.data['ntp']['servers']:
+            self.data['ntp']['method'] = "Manual"
+
+            servers = self.data['ntp']['servers']
+            if len(servers) == 4 and all("centos.pool.ntp.org" in server for server in self.data['ntp']['servers']):
+                self.data['ntp']['method'] = "Default"
+        else:
+            self.data['ntp']['method'] = "Disabled"
 
     def StringToBool(self, inString):
         return inString.lower().startswith('true')
@@ -528,16 +545,94 @@ class Data:
         # Double-check authentication
         Auth.Inst().AssertAuthenticated()
 
-        file = None
         try:
-            file = open("/etc/chrony.conf", "w")
-            for other in self.ntp.othercontents([]):
-                file.write(other+"\n")
-            for server in self.ntp.servers([]):
-                file.write("server "+server+" iburst\n")
+            with open("/etc/chrony.conf", "w") as confFile:
+              for other in self.ntp.othercontents([]):
+                  confFile.write(other + "\n")
+              for server in self.ntp.servers([]):
+                  confFile.write("server " + server + " iburst\n")
         finally:
-            if file is not None: file.close()
             self.UpdateFromNTPConf()
+
+        # Force chronyd to update the time
+        if self.data['ntp']['method'] != "Disabled":
+            servers = self.data['ntp']['servers']
+            if self.data['ntp']['method'] == "DHCP":
+                servers = self.GetDHClientInterfaces()
+
+            if servers:
+                self.StopService("chronyd")
+                getoutput("chronyd -q 'server %s iburst'" % servers[0])  # Update the clock and exit
+                getoutput("hwclock -w")  # Sync hwclock with date set by chronyd
+                self.StartService("chronyd")
+
+    def AddDHCPNTP(self):
+        # Double-check authentication
+        Auth.Inst().AssertAuthenticated()
+
+        oldPermissions = os.stat("/etc/dhcp/dhclient.d/chrony.sh").st_mode
+        newPermissions = oldPermissions | (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod("/etc/dhcp/dhclient.d/chrony.sh", newPermissions)
+
+        interfaces = self.GetDHClientInterfaces()
+        for interface in interfaces:
+            ntpServer = self.GetDHCPNTPServer(interface)
+
+            with open("/var/lib/dhclient/chrony.servers.%s" % interface, "w") as chronyFile:
+                chronyFile.write("%s iburst prefer\n" % ntpServer)
+
+    def ResetDefaultNTPServers(self):
+        # Double-check authentication
+        Auth.Inst().AssertAuthenticated()
+
+        Data.Inst().NTPServersSet(["0.centos.pool.ntp.org",
+                                    "1.centos.pool.ntp.org",
+                                    "2.centos.pool.ntp.org",
+                                    "3.centos.pool.ntp.org"])
+
+    def GetDHClientInterfaces(self):
+        (status, output) = getstatusoutput("ls /var/lib/xcp/ | grep leases")
+        if status != 0:
+          return []
+
+        dhclientFiles = output.splitlines()
+        pattern = "dhclient-(.*).leases"
+        interfaces = []
+        for dhclientFile in dhclientFiles:
+            match = re.match(pattern, dhclientFile)
+            if match:
+                interfaces.append(match.group(1))
+
+        return interfaces
+
+    def GetDHCPNTPServer(self, interface):
+        ntpServer = getoutput("grep ntp-servers /var/lib/xcp/dhclient-%s.leases | tail -1 | awk '{{ print ( $3 ) }}'" % interface).strip()[:-1]
+        return ntpServer
+
+    def RemoveDHCPNTP(self):
+        # Double-check authentication
+        Auth.Inst().AssertAuthenticated()
+
+        oldPermissions = os.stat("/etc/dhcp/dhclient.d/chrony.sh").st_mode
+        newPermissions = oldPermissions & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod("/etc/dhcp/dhclient.d/chrony.sh", newPermissions)
+
+        getstatusoutput("rm -f /var/lib/dhclient/chrony.servers.*")
+
+    def SetTimeManually(self, date):
+        # Double-check authentication
+        Auth.Inst().AssertAuthenticated()
+
+        self.NTPServersSet([])
+        self.RemoveDHCPNTP()
+        self.SaveToNTPConf()
+
+        self.DisableService("chrony-wait")
+        self.DisableService("chronyd")
+
+        timestring = date.strftime("%Y-%m-%d %H:%M:00")
+        getstatusoutput("date --set='%s'" % timestring)
+        getstatusoutput("hwclock --utc --systohc")
 
     def SaveToResolveConf(self):
         # Double-check authentication
@@ -724,9 +819,6 @@ class Data:
         self.data['sysconfig']['network']['hostname'] = inLines[0]
 
     def ScanNTPConf(self, inLines):
-        if not 'ntp' in self.data:
-            self.data['ntp'] = {}
-
         self.data['ntp']['servers'] = []
         self.data['ntp']['othercontents'] = []
 
@@ -952,6 +1044,12 @@ class Data:
         finally:
             # Network reconfigured so this link is potentially no longer valid
             self.session = Auth.Inst().CloseSession(self.session)
+
+    def AdjustNTPForStaticNetwork(self):
+        self.RemoveDHCPNTP()
+        if not self.data['ntp']['servers']: # No NTP servers after removing DHCP
+            self.ResetDefaultNTPServers()
+            self.SaveToNTPConf()
 
     def LocalHostEnable(self):
         Auth.Inst().AssertAuthenticatedOrPasswordUnset()

--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -1229,10 +1229,6 @@ class Data:
         if status != 0:
             raise Exception(output)
 
-    def NTPStatus(self):
-        status, output = getstatusoutput("/usr/bin/ntpstat")
-        return output
-
     def SetVerboseBoot(self, inVerbose):
         if inVerbose:
             name = 'noisy'

--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -496,13 +496,20 @@ class Data:
 
         self.data['ntp']['method'] = ""
         chronyPerm = os.stat("/etc/dhcp/dhclient.d/chrony.sh").st_mode
-        if chronyPerm & stat.S_IXUSR and chronyPerm & stat.S_IXGRP and chronyPerm & stat.S_IXOTH:
+        if (
+            chronyPerm & stat.S_IXUSR
+            and chronyPerm & stat.S_IXGRP
+            and chronyPerm & stat.S_IXOTH
+        ):
             self.data['ntp']['method'] = "DHCP"
         elif self.data['ntp']['servers']:
             self.data['ntp']['method'] = "Manual"
 
             servers = self.data['ntp']['servers']
-            if len(servers) == 4 and all("centos.pool.ntp.org" in server for server in self.data['ntp']['servers']):
+            if len(servers) == 4 and all(
+                "centos.pool.ntp.org" in server
+                for server in self.data['ntp']['servers']
+            ):
                 self.data['ntp']['method'] = "Default"
         else:
             self.data['ntp']['method'] = "Disabled"
@@ -547,10 +554,10 @@ class Data:
 
         try:
             with open("/etc/chrony.conf", "w") as confFile:
-              for other in self.ntp.othercontents([]):
-                  confFile.write(other + "\n")
-              for server in self.ntp.servers([]):
-                  confFile.write("server " + server + " iburst\n")
+                for other in self.ntp.othercontents([]):
+                    confFile.write(other + "\n")
+                for server in self.ntp.servers([]):
+                    confFile.write("server " + server + " iburst\n")
         finally:
             self.UpdateFromNTPConf()
 
@@ -585,15 +592,19 @@ class Data:
         # Double-check authentication
         Auth.Inst().AssertAuthenticated()
 
-        Data.Inst().NTPServersSet(["0.centos.pool.ntp.org",
-                                    "1.centos.pool.ntp.org",
-                                    "2.centos.pool.ntp.org",
-                                    "3.centos.pool.ntp.org"])
+        Data.Inst().NTPServersSet(
+            [
+                "0.centos.pool.ntp.org",
+                "1.centos.pool.ntp.org",
+                "2.centos.pool.ntp.org",
+                "3.centos.pool.ntp.org",
+            ]
+        )
 
     def GetDHClientInterfaces(self):
         (status, output) = getstatusoutput("ls /var/lib/xcp/ | grep leases")
         if status != 0:
-          return []
+            return []
 
         dhclientFiles = output.splitlines()
         pattern = "dhclient-(.*).leases"

--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -569,8 +569,10 @@ class Data:
 
             if servers:
                 self.StopService("chronyd")
-                getoutput("chronyd -q 'server %s iburst'" % servers[0])  # Update the clock and exit
-                getoutput("hwclock -w")  # Sync hwclock with date set by chronyd
+                # Single shot time update like: `ntpdate servers[0]`
+                getoutput("chronyd -q 'server %s iburst'" % servers[0])
+                # Write the system time (set by the single shot NTP) to the HW clock
+                getoutput("hwclock -w")
                 self.StartService("chronyd")
 
     def AddDHCPNTP(self):

--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -506,7 +506,7 @@ class Data:
             self.data['ntp']['method'] = "Manual"
 
             servers = self.data['ntp']['servers']
-            if len(servers) == 4 and all(
+            if len(servers) == NUM_DEFAULT_NTP_SERVERS and all(
                 inDefaultNTPDomains(server)
                 for server in self.data['ntp']['servers']
             ):
@@ -590,10 +590,7 @@ class Data:
     def ResetDefaultNTPServers(self):
         # Double-check authentication
         Auth.Inst().AssertAuthenticated()
-
-        Data.Inst().NTPServersSet(
-            ["%d%s" % (i, DEFAULT_NTP_DOMAINS[0]) for i in range(4)]
-        )
+        Data.Inst().NTPServersSet(DEFAULT_NTP_SERVERS)
 
     def GetDHClientInterfaces(self):
         try:

--- a/XSConsoleDialoguePane.py
+++ b/XSConsoleDialoguePane.py
@@ -190,10 +190,10 @@ class DialoguePane:
         self.AddBodyFieldObj(TextField(str(inName), self.brightColour, Field.FLOW_RIGHT))
         self.AddBodyFieldObj(WrappedTextField(str(inValue), self.baseColour, Field.FLOW_RETURN))
 
-    def AddInputField(self, inName, inValue, inLabel, inLengthLimit = None):
+    def AddInputField(self, inName, inValue, inLabel, inLengthLimit = None, inputWidth=INPUT_FIELD_DEFAULT_WIDTH, flow=Field.FLOW_RETURN):
         self.AddBodyFieldObj(TextField(str(inName), self.brightColour, Field.FLOW_RIGHT))
         self.AddInputFieldObj(InputField(str(inValue), self.highlightColour, self.selectedColour,
-            Field.FLOW_RETURN, inLengthLimit), inLabel)
+            flow, inLengthLimit, width=inputWidth), inLabel)
 
     def AddPasswordField(self, inName, inValue, inLabel, inLengthLimit = None):
         self.AddBodyFieldObj(TextField(str(inName), self.brightColour, Field.FLOW_RIGHT))

--- a/XSConsoleFields.py
+++ b/XSConsoleFields.py
@@ -44,17 +44,18 @@ class SeparatorField(Field):
     def Height(self):
         return 1
 
+INPUT_FIELD_DEFAULT_WIDTH = 40  # Declared for use in constructor
 class InputField(Field):
-    MIN_WIDTH = 40 # Minimum width for input fields
+    MIN_WIDTH = 5  # Minimum width for input fields
 
-    def __init__(self, text, colour, selectedColour, flow, lengthLimit):
+    def __init__(self, text, colour, selectedColour, flow, lengthLimit, width=INPUT_FIELD_DEFAULT_WIDTH):
         ParamsToAttr()
         self.activated = False
         self.cursorPos = len(self.text)
         self.hideText = False
         self.selected = True
         self.scrollPos = 0
-        self.width = self.MIN_WIDTH
+        self.UpdateWidth(width)
         if self.lengthLimit is None:
             self.lengthLimit = 4096
 

--- a/XSConsoleStandard.py
+++ b/XSConsoleStandard.py
@@ -18,6 +18,7 @@
 from XSConsoleAuth import *
 from XSConsoleBases import *
 from XSConsoleConfig import *
+from XSConsoleConstants import *
 from XSConsoleData import *
 from XSConsoleDataUtils import *
 from XSConsoleDialogueBases import *

--- a/XSConsoleTerm.py
+++ b/XSConsoleTerm.py
@@ -30,6 +30,13 @@ from XSConsoleRemoteTest import *
 from XSConsoleRootDialogue import *
 from XSConsoleState import *
 
+
+if sys.version_info >= (3, 0):
+    getTimeStamp = time.monotonic
+else:
+    getTimeStamp = time.time
+
+
 class App:
     __instance = None
 
@@ -53,9 +60,9 @@ class App:
             Importer.ImportRelativeDir(dir)
 
     def Enter(self):
-        startTime = time.time()
+        startTime = getTimeStamp()
         Data.Inst().Update()
-        elapsedTime = time.time() - startTime
+        elapsedTime = getTimeStamp() - startTime
         XSLog('Loaded initial xapi and system data in %.3f seconds' % elapsedTime)
 
         doQuit = False
@@ -158,7 +165,7 @@ class App:
     def HandleKeypress(self, inKeypress):
         handled = True
         Auth.Inst().KeepAlive()
-        self.lastWakeSeconds = time.time()
+        self.lastWakeSeconds = getTimeStamp()
         if self.layout.TopDialogue().HandleKey(inKeypress):
             State.Inst().SaveIfRequired()
             self.needsRefresh = True
@@ -180,7 +187,7 @@ class App:
 
     def MainLoop(self):
         doQuit= False
-        startSeconds = time.time()
+        startSeconds = getTimeStamp()
         lastDataUpdateSeconds = startSeconds
         lastScreenUpdateSeconds = startSeconds
         lastGarbageCollectSeconds = startSeconds
@@ -193,7 +200,7 @@ class App:
         while not doQuit:
             self.needsRefresh = False
             gotTestCommand = RemoteTest.Inst().Poll()
-            secondsNow = time.time()
+            secondsNow = getTimeStamp()
             try:
                 if gotTestCommand:
                     gotKey = None # Prevent delay whilst waiting for a keypress
@@ -205,7 +212,7 @@ class App:
                     XSLog('Entering sleep due to inactivity - xsconsole is now blocked waiting for a keypress')
                     self.layout.Window(Layout.WIN_MAIN).GetKeyBlocking()
                     XSLog('Exiting sleep')
-                    self.lastWakeSeconds = time.time()
+                    self.lastWakeSeconds = getTimeStamp()
                     self.needsRefresh = True
                     Layout.Inst().PopDialogue()
                 else:
@@ -234,7 +241,7 @@ class App:
                     gotKey = None
                     break
 
-            secondsNow = time.time()
+            secondsNow = getTimeStamp()
             secondsRunning = secondsNow - startSeconds
 
             if data.host.address('') == '' or len(data.derived.managementpifs([])) == 0:

--- a/XSConsoleUtils.py
+++ b/XSConsoleUtils.py
@@ -17,6 +17,7 @@ import re, signal, string, subprocess, time, types
 from pprint import pprint
 
 from XSConsoleBases import *
+from XSConsoleConstants import *
 from XSConsoleLang import *
 
 # Utils that need to access Data must go in XSConsoleDataUtils,
@@ -329,4 +330,8 @@ class SizeUtils:
     @classmethod
     def DiskSizeString(cls, inBytes):
         return cls.BinarySizeString(inBytes)+' ('+cls.DecimalSizeString(inBytes)+')'
+
+
+def inDefaultNTPDomains(ntpServer):
+    return any(ntpServer.endswith(defaultDomain) for defaultDomain in DEFAULT_NTP_DOMAINS)
 

--- a/plugins-base/XSFeatureInterface.py
+++ b/plugins-base/XSFeatureInterface.py
@@ -423,11 +423,15 @@ class InterfaceDialogue(Dialogue):
         if self.nic is None:
             self.mode = None
             data.DisableManagement()
+            data.AdjustNTPForStaticNetwork()
+            Layout.Inst().PushDialogue(InfoDialogue(Lang("Removed DHCP NTP server")))
         else:
             pif = data.host.PIFs()[self.nic]
             if self.mode.lower().startswith('static'):
                 # Comma-separated list of nameserver IPs
                 dns = ','.join(data.dns.nameservers([]))
+                data.AdjustNTPForStaticNetwork()
+                Layout.Inst().PushDialogue(InfoDialogue(Lang("Removed DHCP NTP server")))
             else:
                 dns = ''
 

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -41,10 +41,6 @@ class NTPDialogue(Dialogue):
         if usingDHCP:
             choiceDefs.insert(0, ChoiceDef(Lang("Use DHCP NTP Servers"), lambda: self.HandleInitialChoice('DHCP')))
 
-        if Auth.Inst().IsTestMode():
-            # Show Status is a testing-only function
-            choiceDefs.append(ChoiceDef(Lang("Show Status (ntpstat)"), lambda: self.HandleInitialChoice('STATUS') ))
-
         self.initialMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
     def CreateMANUALPane(self):
@@ -164,10 +160,6 @@ class NTPDialogue(Dialogue):
                 self.ChangeState("MANUAL")
             elif inChoice == "NONE":
                 self.ChangeState("NONE")
-
-            elif inChoice == "STATUS":
-                message = data.NTPStatus()+Lang("\n\n(Initial synchronization may take several minutes)")
-                Layout.Inst().PushDialogue( Lang("NTP Status"), message))
 
         except Exception as e:
             Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -30,16 +30,31 @@ class NTPDialogue(Dialogue):
 
     def CreateINITIALPane(self):
         choiceDefs = [
-            ChoiceDef(Lang("Use Default NTP Servers"), lambda: self.HandleInitialChoice('DEFAULT') ),
-            ChoiceDef(Lang("Provide NTP Servers Manually"), lambda: self.HandleInitialChoice('MANUAL') ),
-            ChoiceDef(Lang("Disable NTP (Manual Time Entry)"), lambda: self.HandleInitialChoice('NONE') )
+            ChoiceDef(
+                Lang("Use Default NTP Servers"),
+                lambda: self.HandleInitialChoice('DEFAULT'),
+            ),
+            ChoiceDef(
+                Lang("Provide NTP Servers Manually"),
+                lambda: self.HandleInitialChoice('MANUAL'),
+            ),
+            ChoiceDef(
+                Lang("Disable NTP (Manual Time Entry)"),
+                lambda: self.HandleInitialChoice('NONE'),
+            ),
         ]
 
         data = Data.Inst()
         pifs = data.derived.managementpifs([])
         usingDHCP = any("dhcp" in pif['ip_configuration_mode'].lower() for pif in pifs)
         if usingDHCP:
-            choiceDefs.insert(0, ChoiceDef(Lang("Use DHCP NTP Servers"), lambda: self.HandleInitialChoice('DHCP')))
+            choiceDefs.insert(
+                0,
+                ChoiceDef(
+                    Lang("Use DHCP NTP Servers"),
+                    lambda: self.HandleInitialChoice('DHCP'),
+                ),
+            )
 
         self.initialMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
@@ -53,8 +68,17 @@ class NTPDialogue(Dialogue):
 
         servers = data.ntp.servers([])
         if data.ntp.method("") == "Manual" and len(servers) > 0:
-            choiceDefs.append(ChoiceDef(Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")))
-            choiceDefs.append(ChoiceDef(Lang("Remove All Servers"), lambda: self.HandleManualChoice("REMOVEALL")))
+            choiceDefs.append(
+                ChoiceDef(
+                    Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")
+                )
+            )
+            choiceDefs.append(
+                ChoiceDef(
+                    Lang("Remove All Servers"),
+                    lambda: self.HandleManualChoice("REMOVEALL"),
+                )
+            )
 
         self.manualMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
@@ -88,7 +112,9 @@ class NTPDialogue(Dialogue):
         pane.AddTitleField(Lang("Please Select an Option"))
         self.CreateMANUALPane()
         pane.AddMenuField(self.manualMenu)
-        pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+        pane.AddKeyHelpField(
+            {Lang("<Enter>"): Lang("OK"), Lang("<Esc>"): Lang("Cancel")}
+        )
 
     def UpdateFieldsNONE(self):
         now = datetime.datetime.now()
@@ -132,7 +158,12 @@ class NTPDialogue(Dialogue):
         choiceDefs = []
         for server in Data.Inst().ntp.servers([]):
             XSLog("Adding server to remove menu: " + server)
-            choiceDefs.append(ChoiceDef(Lang(server), lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex())))
+            choiceDefs.append(
+                ChoiceDef(
+                    Lang(server),
+                    lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex()),
+                )
+            )
 
         self.removeMenu = Menu(self, None, Lang("Remove NTP Server"), choiceDefs)
 

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -67,7 +67,7 @@ class NTPDialogue(Dialogue):
         data.UpdateFromNTPConf()
 
         servers = data.ntp.servers([])
-        if data.ntp.method("") == "Manual" and len(servers) > 0:
+        if len(servers) > 0:
             choiceDefs.append(
                 ChoiceDef(
                     Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")
@@ -302,9 +302,6 @@ class NTPDialogue(Dialogue):
                 IPUtils.AssertValidNetworkName(inputValues['name'])
 
                 data=Data.Inst()
-                if data.ntp.method("") == "Default":
-                    data.NTPServersSet([server for server in data.ntp.servers([]) if not inDefaultNTPDomains(server)])
-
                 data.RemoveDHCPNTP()
 
                 servers = data.ntp.servers([])

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -303,7 +303,7 @@ class NTPDialogue(Dialogue):
 
                 data=Data.Inst()
                 if data.ntp.method("") == "Default":
-                    data.NTPServersSet([server for server in data.ntp.servers([]) if "centos.pool.ntp.org" not in server])
+                    data.NTPServersSet([server for server in data.ntp.servers([]) if not inDefaultNTPDomains(server)])
 
                 data.RemoveDHCPNTP()
 

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -16,60 +16,115 @@
 if __name__ == "__main__":
     raise Exception("This script is a plugin for xsconsole and cannot run independently")
 
+import datetime
+
+
 from XSConsoleStandard import *
+from XSConsoleFields import Field
+
 
 class NTPDialogue(Dialogue):
     def __init__(self):
         Dialogue.__init__(self)
+        self.ChangeState("INITIAL")
 
-        data=Data.Inst()
-
+    def CreateINITIALPane(self):
         choiceDefs = [
-            ChoiceDef(Lang("Enable NTP Time Synchronization"), lambda: self.HandleInitialChoice('ENABLE') ),
-            ChoiceDef(Lang("Disable NTP Time Synchronization"), lambda: self.HandleInitialChoice('DISABLE') ),
-            ChoiceDef(Lang("Add an NTP Server"), lambda: self.HandleInitialChoice('ADD') ) ]
+            ChoiceDef(Lang("Use Default NTP Servers"), lambda: self.HandleInitialChoice('DEFAULT') ),
+            ChoiceDef(Lang("Provide NTP Servers Manually"), lambda: self.HandleInitialChoice('MANUAL') ),
+            ChoiceDef(Lang("Disable NTP (Manual Time Entry)"), lambda: self.HandleInitialChoice('NONE') )
+        ]
 
-        if len(data.ntp.servers([])) > 0:
-            choiceDefs.append(ChoiceDef(Lang("Remove a Single NTP Server"), lambda: self.HandleInitialChoice('REMOVE') ))
-            choiceDefs.append(ChoiceDef(Lang("Remove All NTP Servers"), lambda: self.HandleInitialChoice('REMOVEALL') ))
+        data = Data.Inst()
+        pifs = data.derived.managementpifs([])
+        usingDHCP = any("dhcp" in pif['ip_configuration_mode'].lower() for pif in pifs)
+        if usingDHCP:
+            choiceDefs.insert(0, ChoiceDef(Lang("Use DHCP NTP Servers"), lambda: self.HandleInitialChoice('DHCP')))
 
         if Auth.Inst().IsTestMode():
             # Show Status is a testing-only function
             choiceDefs.append(ChoiceDef(Lang("Show Status (ntpstat)"), lambda: self.HandleInitialChoice('STATUS') ))
 
-        self.ntpMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
+        self.initialMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
-        self.ChangeState('INITIAL')
+    def CreateMANUALPane(self):
+        choiceDefs = [
+            ChoiceDef(Lang("Add New Server"), lambda: self.HandleManualChoice("ADD"))
+        ]
+
+        data = Data.Inst()
+        data.UpdateFromNTPConf()
+
+        servers = data.ntp.servers([])
+        if data.ntp.method("") == "Manual" and len(servers) > 0:
+            choiceDefs.append(ChoiceDef(Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")))
+            choiceDefs.append(ChoiceDef(Lang("Remove All Servers"), lambda: self.HandleManualChoice("REMOVEALL")))
+
+        self.manualMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
+
+    def ChangeState(self, state):
+        self.state = state
+        self.BuildPane()
 
     def BuildPane(self):
-        if self.state == 'REMOVE':
-            choiceDefs = []
-            for server in Data.Inst().ntp.servers([]):
-                choiceDefs.append(ChoiceDef(server, lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex())))
-
-            self.removeMenu = Menu(self, None, Lang("Remove NTP Server"), choiceDefs)
-
         pane = self.NewPane(DialoguePane(self.parent))
         pane.TitleSet(Lang("Configure Network Time"))
         pane.AddBox()
         self.UpdateFields()
+
+    def UpdateFields(self):
+        self.Pane().ResetPosition()
+        getattr(self, "UpdateFields" + self.state)() # Dispatch method named 'UpdateFields' + self.state
 
     def UpdateFieldsINITIAL(self):
         pane = self.Pane()
         pane.ResetFields()
 
         pane.AddTitleField(Lang("Please Select an Option"))
-        pane.AddMenuField(self.ntpMenu)
+        self.CreateINITIALPane()
+        pane.AddMenuField(self.initialMenu)
         pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+    def UpdateFieldsMANUAL(self):
+        pane = self.Pane()
+        pane.ResetFields()
+
+        pane.AddTitleField(Lang("Please Select an Option"))
+        self.CreateMANUALPane()
+        pane.AddMenuField(self.manualMenu)
+        pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+    def UpdateFieldsNONE(self):
+        now = datetime.datetime.now()
+
+        pane = self.Pane()
+        pane.ResetFields()
+
+        pane.TitleSet(Lang("Set Current Time"))
+        pane.AddTitleField(Lang("Please set the current (local) date and time"))
+        pane.NewLine()
+
+        pane.AddInputField(Lang("Year: "), str(now.year), "year", inLengthLimit=4, flow=Field.FLOW_RIGHT, inputWidth=5)
+        pane.AddInputField(Lang("Month: "), "{:02d}".format(now.month), "month", inLengthLimit=2, flow=Field.FLOW_RIGHT, inputWidth=5)
+        pane.AddInputField(Lang("Day: "), "{:02d}".format(now.day), "day", inLengthLimit=2, inputWidth=5)
+        pane.NewLine()
+
+        pane.AddInputField(Lang("Hour (24h): "), "{:02d}".format(now.hour), "hour", inLengthLimit=2, flow=Field.FLOW_RIGHT, inputWidth=5)
+        pane.AddInputField(Lang("Minute: "), "{:02d}".format(now.minute), "minute", inLengthLimit=2, inputWidth=5)
+
+        pane.AddKeyHelpField( { Lang("<Up/Down>") : Lang("Next/Prev"), Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+        if pane.CurrentInput is None:
+            pane.InputIndexSet(0)
 
     def UpdateFieldsADD(self):
         pane = self.Pane()
         pane.ResetFields()
 
-        pane.AddTitleField(Lang("Please Enter the NTP Server Name or Address"))
-        pane.AddWrappedTextField(Lang("NTP servers supplied by DHCP may overwrite values configured here."))
+        pane.AddTitleField(Lang("Please Enter the NTP Server Name(s) or Address(es)"))
         pane.NewLine()
         pane.AddInputField(Lang("Server", 16), '', 'name')
+
         pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK") , Lang("<Esc>") : Lang("Cancel") } )
         if pane.CurrentInput() is None:
             pane.InputIndexSet(0)
@@ -78,51 +133,79 @@ class NTPDialogue(Dialogue):
         pane = self.Pane()
         pane.ResetFields()
 
-        pane.AddTitleField(Lang("Select Server Entry to Remove"))
-        pane.AddWrappedTextField(Lang("NTP servers supplied by DHCP may overwrite values configured here."))
-        pane.NewLine()
+        choiceDefs = []
+        for server in Data.Inst().ntp.servers([]):
+            XSLog("Adding server to remove menu: " + server)
+            choiceDefs.append(ChoiceDef(Lang(server), lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex())))
+
+        self.removeMenu = Menu(self, None, Lang("Remove NTP Server"), choiceDefs)
 
         pane.AddMenuField(self.removeMenu)
         pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
 
-    def UpdateFields(self):
-        self.Pane().ResetPosition()
-        getattr(self, 'UpdateFields'+self.state)() # Despatch method named 'UpdateFields'+self.state
+    def HandleInitialChoice(self, inChoice):
+        data = Data.Inst()
+        try:
+            if inChoice == "DHCP":
+                Layout.Inst().PopDialogue()
+                Layout.Inst().TransientBanner(Lang("Enabling DHCP NTP Server..."))
+                data.NTPServersSet([])
+                data.AddDHCPNTP()
+                self.Commit(Lang("DHCP NTP Time Synchronization Enabled"))
 
-    def ChangeState(self, inState):
-        self.state = inState
-        self.BuildPane()
+            elif inChoice == "DEFAULT":
+                Layout.Inst().PopDialogue()
+                Layout.Inst().TransientBanner(Lang("Enabling Default NTP Servers..."))
+                data.ResetDefaultNTPServers()
+                data.RemoveDHCPNTP()
+                self.Commit(Lang("Default NTP Time Synchronization Enabled"))
 
-    def HandleKeyINITIAL(self, inKey):
-        return self.ntpMenu.HandleKey(inKey)
+            elif inChoice == "MANUAL":
+                self.ChangeState("MANUAL")
+            elif inChoice == "NONE":
+                self.ChangeState("NONE")
 
-    def HandleKeyADD(self, inKey):
-        handled = True
-        pane = self.Pane()
-        if pane.CurrentInput() is None:
-            pane.InputIndexSet(0)
-        if inKey == 'KEY_ENTER':
-            inputValues = pane.GetFieldValues()
-            Layout.Inst().PopDialogue()
-            try:
-                IPUtils.AssertValidNetworkName(inputValues['name'])
-                data=Data.Inst()
-                servers = data.ntp.servers([])
-                servers.append(inputValues['name'])
-                data.NTPServersSet(servers)
-                self.Commit(Lang("NTP server")+" "+inputValues['name']+" "+Lang("added"))
-            except Exception as e:
-                Layout.Inst().PushDialogue(InfoDialogue(Lang(e)))
-        elif pane.CurrentInput().HandleKey(inKey):
-            pass # Leave handled as True
-        else:
-            handled = False
-        return handled
+            elif inChoice == "STATUS":
+                message = data.NTPStatus()+Lang("\n\n(Initial synchronization may take several minutes)")
+                Layout.Inst().PushDialogue( Lang("NTP Status"), message))
 
-    def HandleKeyREMOVE(self, inKey):
-        return self.removeMenu.HandleKey(inKey)
+        except Exception as e:
+            Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))
 
-    def HandleKey(self,  inKey):
+        data.Update()
+
+    def HandleManualChoice(self, inChoice):
+        data = Data.Inst()
+        try:
+            if inChoice == "ADD":
+                self.ChangeState("ADD")
+            elif inChoice == "REMOVE":
+                self.ChangeState("REMOVE")
+            elif inChoice == "REMOVEALL":
+                Layout.Inst().PopDialogue()
+                Layout.Inst().TransientBanner(Lang("Removing All NTP Servers..."))
+                data.NTPServersSet([])
+                self.Commit(Lang("All server entries deleted"))
+
+        except Exception as e:
+            Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))
+
+        data.Update()
+
+    def HandleRemoveChoice(self, inChoice):
+        data = Data.Inst()
+        servers = data.ntp.servers([])
+        thisServer = servers[inChoice]
+
+        Layout.Inst().PopDialogue()
+        Layout.Inst().TransientBanner(Lang("Removing %s NTP Server..." % thisServer))
+
+        del servers[inChoice]
+        data.NTPServersSet(servers)
+        self.Commit(Lang("NTP server %s deleted" % thisServer))
+        data.Update()
+
+    def HandleKey(self, inKey): # Route any menu key presses to the current state handler
         handled = False
         if hasattr(self, 'HandleKey'+self.state):
             handled = getattr(self, 'HandleKey'+self.state)(inKey)
@@ -133,53 +216,95 @@ class NTPDialogue(Dialogue):
 
         return handled
 
-    def HandleInitialChoice(self,  inChoice):
-        data = Data.Inst()
-        try:
-            if inChoice == 'ENABLE':
-                Layout.Inst().TransientBanner(Lang("Enabling..."))
-                data.EnableService('chronyd')
-                data.EnableService('chrony-wait')
-                data.StartService('chronyd')
-                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Time Synchronization Enabled")))
-            elif inChoice == 'DISABLE':
-                Layout.Inst().TransientBanner(Lang("Disabling..."))
-                data.DisableService('chronyd')
-                data.DisableService('chrony-wait')
-                data.StopService('chronyd')
-                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Time Synchronization Disabled")))
-            elif inChoice == 'ADD':
-                self.ChangeState('ADD')
-            elif inChoice == 'REMOVE':
-                self.ChangeState('REMOVE')
-            elif inChoice == 'REMOVEALL':
-                Layout.Inst().PopDialogue()
-                data.NTPServersSet([])
-                self.Commit(Lang("All server entries deleted"))
-            elif inChoice == 'STATUS':
-                message = data.NTPStatus()+Lang("\n\n(Initial synchronization may take several minutes)")
-                Layout.Inst().PushDialogue(InfoDialogue( Lang("NTP Status"), message))
+    def HandleKeyINITIAL(self, inKey):
+        return self.initialMenu.HandleKey(inKey)
 
-        except Exception as e:
-            Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))
+    def HandleKeyMANUAL(self, inKey):
+        return self.manualMenu.HandleKey(inKey)
 
-        data.Update()
+    def HandleKeyNONE(self, inKey):
+        handled = True
+        pane = self.Pane()
+        if pane.CurrentInput() is None:
+            pane.InputIndexSet(0)
 
-    def HandleRemoveChoice(self,  inChoice):
-        Layout.Inst().PopDialogue()
-        data=Data.Inst()
-        servers = data.ntp.servers([])
-        thisServer = servers[inChoice]
-        del servers[inChoice]
-        data.NTPServersSet(servers)
-        self.Commit(Lang("NTP server")+" "+thisServer+" "+Lang("deleted"))
-        data.Update()
+        if inKey == 'KEY_ENTER':
+            inputValues = pane.GetFieldValues()
+            Layout.Inst().PopDialogue()
 
-    def Commit(self, inMessage):
+            try:
+                year = inputValues["year"].strip()
+                month = inputValues["month"].strip()
+                day = inputValues["day"].strip()
+                hour = inputValues["hour"].strip()
+                minute = inputValues["minute"].strip()
+
+                date_string = "%04d-%02d-%02d %02d:%02d:00" % (int(year), int(month), int(day), int(hour), int(minute))
+                date_format = "%Y-%m-%d %H:%M:00"
+                date = datetime.datetime.strptime(date_string, date_format)
+
+                Layout.Inst().TransientBanner(Lang("Setting Time..."))
+                data = Data.Inst()
+                data.RemoveDHCPNTP()
+                data.SetTimeManually(date)
+
+                self.Commit(Lang("Time Set Manually"), restartChronyd=False)
+            except Exception as e:
+                Layout.Inst().PushDialogue(InfoDialogue(Lang(e)))
+
+        elif inKey == 'KEY_DOWN':
+            newIndex = (pane.InputIndex() + 1) % pane.fieldGroup.NumInputFields()
+            pane.InputIndexSet(newIndex)
+        elif inKey == 'KEY_UP':
+            newIndex = (pane.InputIndex() - 1) % pane.fieldGroup.NumInputFields()
+            pane.InputIndexSet(newIndex)
+
+        elif pane.CurrentInput().HandleKey(inKey):
+            pass
+        else:
+            handled = False
+
+        return handled
+
+    def HandleKeyADD(self, inKey):
+        handled = True
+        pane = self.Pane()
+        if pane.CurrentInput() is None:
+            pane.InputIndexSet(0)
+        if inKey == 'KEY_ENTER':
+            inputValues = pane.GetFieldValues()
+            Layout.Inst().PopDialogue()
+            Layout.Inst().TransientBanner(Lang("Adding %s NTP Server..." % inputValues['name']))
+            try:
+                IPUtils.AssertValidNetworkName(inputValues['name'])
+
+                data=Data.Inst()
+                if data.ntp.method("") == "Default":
+                    data.NTPServersSet([server for server in data.ntp.servers([]) if "centos.pool.ntp.org" not in server])
+
+                data.RemoveDHCPNTP()
+
+                servers = data.ntp.servers([])
+                servers.append(inputValues['name'])
+                data.NTPServersSet(servers)
+                self.Commit(Lang("NTP server")+" "+inputValues['name']+" "+Lang("added"))
+            except Exception as e:
+                Layout.Inst().PushDialogue(InfoDialogue(Lang(e)))
+
+        elif pane.CurrentInput().HandleKey(inKey):
+            pass # Leave handled as True
+        else:
+            handled = False
+        return handled
+
+    def HandleKeyREMOVE(self, inKey):
+        return self.removeMenu.HandleKey(inKey)
+
+    def Commit(self, inMessage, restartChronyd=True):
         data=Data.Inst()
         try:
             data.SaveToNTPConf()
-            if data.chkconfig.chronyd(False):
+            if restartChronyd:
                 Layout.Inst().TransientBanner(Lang("Restarting NTP daemon with new configuration..."))
                 data.RestartService('chronyd')
             Layout.Inst().PushDialogue(InfoDialogue( inMessage))
@@ -188,28 +313,39 @@ class NTPDialogue(Dialogue):
 
         data.Update()
 
+
 class XSFeatureNTP:
     @classmethod
     def StatusUpdateHandler(cls, inPane):
         data = Data.Inst()
+        data.UpdateFromNTPConf()
+
         inPane.AddTitleField(Lang("Network Time (NTP)"))
 
         inPane.AddWrappedTextField(Lang("One or more network time servers can be configured to synchronize time between servers.  This is especially important for pooled servers."))
         inPane.NewLine()
 
-        if not data.chkconfig.chronyd(False):
-            inPane.AddWrappedTextField(Lang("Currently NTP is disabled, and the following servers are configured."))
+        ntpMethod = data.ntp.method("<Unknown>")
+        if ntpMethod == "Disabled":
+            inPane.AddWrappedTextField(Lang("Currently NTP is disabled."))
         else:
             inPane.AddWrappedTextField(Lang("Currently NTP is enabled, and the following servers are configured."))
 
-        inPane.NewLine()
+            servers = data.ntp.servers([])
+            if ntpMethod == "DHCP":
+                gateway = data.ManagementGateway()
+                if gateway is None:
+                    gateway = "Refreshing..."
 
-        servers = data.ntp.servers([])
-        if len(servers) == 0:
-            inPane.AddWrappedTextField(Lang("<No servers configured>"))
-        else:
-            for server in servers:
-                inPane.AddWrappedTextField(server)
+                servers = [Lang(str(gateway) + " (DHCP)")]
+
+            inPane.NewLine()
+
+            if len(servers) == 0:
+                inPane.AddWrappedTextField(Lang("<No servers configured>"))
+            else:
+                for server in servers:
+                    inPane.AddWrappedTextField(server)
 
         inPane.AddKeyHelpField( {
             Lang("<Enter>") : Lang("Reconfigure"),

--- a/plugins-base/XSMenuLayout.py
+++ b/plugins-base/XSMenuLayout.py
@@ -52,6 +52,7 @@ class XSMenuLayout:
 
     def UpdateFieldsNETWORK(self, inPane):
         data = Data.Inst()
+        data.UpdateFromNTPConf()
 
         inPane.AddTitleField(Lang("Network and Management Interface"))
 
@@ -62,10 +63,6 @@ class XSMenuLayout:
             inPane.AddWrappedTextField(Lang("Currently, no management interface is configured."))
         else:
             inPane.AddTitleField(Lang("Current Management Interface"))
-            if data.chkconfig.chronyd(False):
-                ntpState = 'Enabled'
-            else:
-                ntpState = 'Disabled'
 
             for pif in data.derived.managementpifs([]):
                 inPane.AddStatusField(Lang('Device', 16), pif['device'])
@@ -78,7 +75,8 @@ class XSMenuLayout:
                 inPane.AddStatusField(Lang('Netmask', 16),  data.ManagementNetmask(''))
                 inPane.AddStatusField(Lang('Gateway', 16),  data.ManagementGateway(''))
                 inPane.AddStatusField(Lang('Hostname', 16),  data.host.hostname(''))
-                inPane.AddStatusField(Lang('NTP', 16),  ntpState)
+
+                inPane.AddStatusField(Lang('NTP', 16),  data.ntp.method(''))
 
         inPane.AddKeyHelpField( { Lang("<F5>") : Lang("Refresh")})
 


### PR DESCRIPTION
These changes implement NTP control in xsconsole to match the NTP options available in the host-installer

To keep the xsconsole time up to date, the console must use monotonic time (via ncurses) to ensure the console doesn't wait for any negative timesteps before updating (there is an open PR for this behaviour in XenServer) (the console will also update the time upon receiving user input if monotonic time is not used)

Also remove the testing option for the NTP feature as ntpstat is no longer present.

DHCP - Use DHCP server as NTP server
Default - Use the default centos pool NTP servers
Manual - Use manually specified NTP servers
None - Set time manually, no NTP