### PR TITLE
Apply selected suggestions courtesy of darker (from black)

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -496,13 +496,20 @@ class Data:
 
         self.data['ntp']['method'] = ""
         chronyPerm = os.stat("/etc/dhcp/dhclient.d/chrony.sh").st_mode
-        if chronyPerm & stat.S_IXUSR and chronyPerm & stat.S_IXGRP and chronyPerm & stat.S_IXOTH:
+        if (
+            chronyPerm & stat.S_IXUSR
+            and chronyPerm & stat.S_IXGRP
+            and chronyPerm & stat.S_IXOTH
+        ):
             self.data['ntp']['method'] = "DHCP"
         elif self.data['ntp']['servers']:
             self.data['ntp']['method'] = "Manual"
 
             servers = self.data['ntp']['servers']
-            if len(servers) == 4 and all("centos.pool.ntp.org" in server for server in self.data['ntp']['servers']):
+            if len(servers) == 4 and all(
+                "centos.pool.ntp.org" in server
+                for server in self.data['ntp']['servers']
+            ):
                 self.data['ntp']['method'] = "Default"
         else:
             self.data['ntp']['method'] = "Disabled"
@@ -547,10 +554,10 @@ class Data:
 
         try:
             with open("/etc/chrony.conf", "w") as confFile:
-              for other in self.ntp.othercontents([]):
-                  confFile.write(other + "\n")
-              for server in self.ntp.servers([]):
-                  confFile.write("server " + server + " iburst\n")
+                for other in self.ntp.othercontents([]):
+                    confFile.write(other + "\n")
+                for server in self.ntp.servers([]):
+                    confFile.write("server " + server + " iburst\n")
         finally:
             self.UpdateFromNTPConf()
 
@@ -585,15 +592,19 @@ class Data:
         # Double-check authentication
         Auth.Inst().AssertAuthenticated()
 
-        Data.Inst().NTPServersSet(["0.centos.pool.ntp.org",
-                                    "1.centos.pool.ntp.org",
-                                    "2.centos.pool.ntp.org",
-                                    "3.centos.pool.ntp.org"])
+        Data.Inst().NTPServersSet(
+            [
+                "0.centos.pool.ntp.org",
+                "1.centos.pool.ntp.org",
+                "2.centos.pool.ntp.org",
+                "3.centos.pool.ntp.org",
+            ]
+        )
 
     def GetDHClientInterfaces(self):
         (status, output) = getstatusoutput("ls /var/lib/xcp/ | grep leases")
         if status != 0:
-          return []
+            return []
 
         dhclientFiles = output.splitlines()
         pattern = "dhclient-(.*).leases"


### PR DESCRIPTION
Courtesy of the tool `darker` (applies black to the changes in a `git diff`),
here is a set of a few minor formatting suggestions it makes for #35.

This is an incremental PR for #35 (it can be merged/squashed into #35 or reviewed afterwards):

This PR only applies to the 2nd commit of #35, so it could be pulled and squashed into it:
[CA-369899: Add NTP options DHCP|Default|Manual|None](https://github.com/xapi-project/xsconsole/pull/35/commits/a992e30e1b1c533c4cf6b7320c42402b69f346c0#top)

I ran:
```py
pip install darker
darker -r master -S -l 88 .
```
(88 columns is the default of black - take look yourself, it looks sensible to me too)

As this branch is on the same origin repo, you can e.g. run
```py
git fetch origin
git cherry-pick aef00d4d7d73b58ef05a2a62e4fe5a9eb5adcfde
git rebase -i HEAD~3

```
and squash it into the commit [CA-369899: Add NTP options DHCP|Default|Manual|None](https://github.com/xapi-project/xsconsole/pull/35/commits/a992e30e1b1c533c4cf6b7320c42402b69f346c0#top)

Current commit:
[Apply selected suggestions courtesy of darker (from black)](https://github.com/xapi-project/xsconsole/commit/aef00d4d7d73b58ef05a2a62e4fe5a9eb5adcfde)