### PR TITLE
XSFeatureNTP: Apply selected suggestions courtesy of darker(from black)

### DIFF
--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -30,16 +30,31 @@ class NTPDialogue(Dialogue):
 
     def CreateINITIALPane(self):
         choiceDefs = [
-            ChoiceDef(Lang("Use Default NTP Servers"), lambda: self.HandleInitialChoice('DEFAULT') ),
-            ChoiceDef(Lang("Provide NTP Servers Manually"), lambda: self.HandleInitialChoice('MANUAL') ),
-            ChoiceDef(Lang("Disable NTP (Manual Time Entry)"), lambda: self.HandleInitialChoice('NONE') )
+            ChoiceDef(
+                Lang("Use Default NTP Servers"),
+                lambda: self.HandleInitialChoice('DEFAULT'),
+            ),
+            ChoiceDef(
+                Lang("Provide NTP Servers Manually"),
+                lambda: self.HandleInitialChoice('MANUAL'),
+            ),
+            ChoiceDef(
+                Lang("Disable NTP (Manual Time Entry)"),
+                lambda: self.HandleInitialChoice('NONE'),
+            ),
         ]
 
         data = Data.Inst()
         pifs = data.derived.managementpifs([])
         usingDHCP = any("dhcp" in pif['ip_configuration_mode'].lower() for pif in pifs)
         if usingDHCP:
-            choiceDefs.insert(0, ChoiceDef(Lang("Use DHCP NTP Servers"), lambda: self.HandleInitialChoice('DHCP')))
+            choiceDefs.insert(
+                0,
+                ChoiceDef(
+                    Lang("Use DHCP NTP Servers"),
+                    lambda: self.HandleInitialChoice('DHCP'),
+                ),
+            )
 
         self.initialMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
@@ -53,8 +68,17 @@ class NTPDialogue(Dialogue):
 
         servers = data.ntp.servers([])
         if data.ntp.method("") == "Manual" and len(servers) > 0:
-            choiceDefs.append(ChoiceDef(Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")))
-            choiceDefs.append(ChoiceDef(Lang("Remove All Servers"), lambda: self.HandleManualChoice("REMOVEALL")))
+            choiceDefs.append(
+                ChoiceDef(
+                    Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")
+                )
+            )
+            choiceDefs.append(
+                ChoiceDef(
+                    Lang("Remove All Servers"),
+                    lambda: self.HandleManualChoice("REMOVEALL"),
+                )
+            )
 
         self.manualMenu = Menu(self, None, Lang("Configure Network Time"), choiceDefs)
 
@@ -88,7 +112,9 @@ class NTPDialogue(Dialogue):
         pane.AddTitleField(Lang("Please Select an Option"))
         self.CreateMANUALPane()
         pane.AddMenuField(self.manualMenu)
-        pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+        pane.AddKeyHelpField(
+            {Lang("<Enter>"): Lang("OK"), Lang("<Esc>"): Lang("Cancel")}
+        )
 
     def UpdateFieldsNONE(self):
         now = datetime.datetime.now()
@@ -132,7 +158,12 @@ class NTPDialogue(Dialogue):
         choiceDefs = []
         for server in Data.Inst().ntp.servers([]):
             XSLog("Adding server to remove menu: " + server)
-            choiceDefs.append(ChoiceDef(Lang(server), lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex())))
+            choiceDefs.append(
+                ChoiceDef(
+                    Lang(server),
+                    lambda: self.HandleRemoveChoice(self.removeMenu.ChoiceIndex()),
+                )
+            )
 
         self.removeMenu = Menu(self, None, Lang("Remove NTP Server"), choiceDefs)
 


### PR DESCRIPTION
### For the file XSFeatureNTP.py:

Courtesy of the tool `darker` (applies black to the changes in a `git diff`),
here is a set of a few minor formatting suggestions it makes for #35 for the file XSFeatureNTP.py:

This is an incremental PR for #35 (it can be merged/squashed into #35 or reviewed afterwards):

This PR only applies to the 2nd commit of #35, so it could be pulled and squashed into it:
[CA-369899: Add NTP options DHCP|Default|Manual|None](https://github.com/xapi-project/xsconsole/pull/35/commits/a992e30e1b1c533c4cf6b7320c42402b69f346c0#top)

I ran:
```py
pip install darker
darker -r master -S -l 88 .
```
(88 columns is the default of black - take look yourself, it looks sensible to me too)

As this branch is on the same origin repo, you can e.g. run
```py
git fetch origin
git cherry-pick e18244ad9036680bba3644f27fb8ef57450327ce
git rebase -i HEAD~3
# move it after "CA-369899: Add NTP options", change "pick" to "s" (squash), save.
```
and squash it into the commit [CA-369899: Add NTP options DHCP|Default|Manual|None](https://github.com/xapi-project/xsconsole/pull/35/commits/a992e30e1b1c533c4cf6b7320c42402b69f346c0#top)

The commit:
[XSFeatureNTP: Apply selected suggestions courtesy of darker(from black)](https://github.com/xapi-project/xsconsole/commit/e18244ad9036680bba3644f27fb8ef57450327ce)
