### PR TITLE
CA-388527 xsconsole: 'timed out' when creating an ISCSI SR

### DIFF
--- a/XSConsoleDialogueBases.py
+++ b/XSConsoleDialogueBases.py
@@ -634,10 +634,14 @@ class SRDialogue(Dialogue):
         self.DoAction(self.choices[inChoice].sr)
 
 class ProgressDialogue(Dialogue):
-    def __init__(self, inTask, inText):
+    def __init__(self, inTask, inText, *args, OnComplete=None):
         Dialogue.__init__(self)
         self.task = inTask
         self.text = inText
+        # OnComplete is a function to call when the task completes
+        # Used for getting task result and do something after the task completes
+        self.OnComplete = OnComplete
+        self.args = args # Arguments to pass to OnComplete
 
         self.ChangeState('INITIAL')
 
@@ -745,6 +749,8 @@ class ProgressDialogue(Dialogue):
     def HandleCompletion(self):
         # This method is called from UpdateFields, so shouldn't pop the dialogue, etc.
         self.ChangeState('COMPLETE')
+        if self.OnComplete:
+            self.OnComplete(self.task, *self.args)
 
 class DialogueUtils:
     # Helper for activate

--- a/XSConsoleTask.py
+++ b/XSConsoleTask.py
@@ -25,6 +25,7 @@ class TaskEntry:
         self.completed = False
         self.creationTime = None
         self.finishTime = None
+        self.result = None
 
     def Completed(self):
         return self.completed
@@ -37,6 +38,10 @@ class TaskEntry:
 
         self.creationTime = TimeUtils.DateTimeToSecs(self.session.xenapi.task.get_created(self.hotOpaqueRef.OpaqueRef()))
         self.finishTime = TimeUtils.DateTimeToSecs(self.session.xenapi.task.get_finished(self.hotOpaqueRef.OpaqueRef()))
+        if inStatus.startswith('success'):
+            result = self.session.xenapi.task.get_result(self.hotOpaqueRef.OpaqueRef())
+            result = result.replace("<value>", "").replace("</value>", "")
+            self.result = HotOpaqueRef(result, 'any')
         if inStatus.startswith('failure'):
             self.errorInfo = self.session.xenapi.task.get_error_info(self.hotOpaqueRef.OpaqueRef())
 
@@ -53,11 +58,7 @@ class TaskEntry:
         return status
 
     def Result(self):
-        if self.Completed():
-            result = self.completionStatus
-        else:
-            result= self.session.xenapi.task.get_status(self.hotOpaqueRef.OpaqueRef())
-        return HotOpaqueRef(result, 'any')
+        return self.result
 
     def CanCancel(self):
         if self.Completed():

--- a/plugins-base/XSFeatureSRCreate.py
+++ b/plugins-base/XSFeatureSRCreate.py
@@ -1172,9 +1172,8 @@ class SRNewDialogue(Dialogue):
 
     def CommitCreate(self, inType, inDeviceConfig, inOtherConfig = None):
         Layout.Inst().PopDialogue()
-        Layout.Inst().TransientBanner(Lang('Creating Storage Repository...'))
         try:
-            srRef = Task.Sync(lambda x: x.xenapi.SR.create(
+            async_task = Task.New(lambda x: x.xenapi.Async.SR.create(
                 HotAccessor().local_host_ref().OpaqueRef(), # host
                 inDeviceConfig,
                 '0', # physical_size
@@ -1185,17 +1184,27 @@ class SRNewDialogue(Dialogue):
                 True # shared
                 )
             )
+            messagePrefix = Lang('Creating Storage Repository')
+            # Call back for when the SR.create operation completes
+            def create_sr_complete_callback(async_task, inOtherConfig):
+                srRef = async_task.Result()
+                if not srRef:
+                    Layout.Inst().PushDialogue(InfoDialogue(Lang("Storage Repository Creation Failed"), async_task.Message()))
+                else:
+                    # Set values in other_config only if the SR.create operation hasn't already set them
+                    for key, value in FirstValue(inOtherConfig, {}).items():
+                        try:
+                            Task.Sync(lambda x:x.xenapi.SR.add_to_other_config(srRef.OpaqueRef(), key, value))
+                        except Exception:
+                            pass #  Ignore failure
 
-            # Set values in other_config only if the SR.create operation hasn't already set them
-            for key, value in FirstValue(inOtherConfig, {}).items():
-                try:
-                    Task.Sync(lambda x:x.xenapi.SR.add_to_other_config(srRef, key, value))
-                except:
-                    pass #  Ignore failure
+                    Data.Inst().Update()
+                    Data.Inst().SetPoolSRIfRequired(srRef.OpaqueRef())
+                    Layout.Inst().PushDialogue(InfoDialogue(Lang("Storage Repository Creation Successful")))
 
-            Data.Inst().Update()
-            Data.Inst().SetPoolSRIfRequired(srRef)
-            Layout.Inst().PushDialogue(InfoDialogue(Lang("Storage Repository Creation Successful")))
+            Layout.Inst().PushDialogue(ProgressDialogue(async_task, messagePrefix,
+                                                        create_sr_complete_callback,
+                                                        inOtherConfig))
 
         except Exception as e:
             Layout.Inst().PushDialogue(InfoDialogue(Lang("Storage Repository Creation Failed"), Lang(e)))


### PR DESCRIPTION
The XSConsoleAuth set socket timout value to 15 seconds,
and it's not enough for the SR.create.
Use xenapi.Async call instead.

Test passed:
![image](https://github.com/xapi-project/xsconsole/assets/131341002/f268fd3d-ab94-4b40-b0a5-2685b6c2988b)

