### PR TITLE
CA-388527: Fix keyword argument order error

### DIFF
--- a/plugins-base/XSFeatureSRCreate.py
+++ b/plugins-base/XSFeatureSRCreate.py
@@ -1203,8 +1203,8 @@ class SRNewDialogue(Dialogue):
                     Layout.Inst().PushDialogue(InfoDialogue(Lang("Storage Repository Creation Successful")))
 
             Layout.Inst().PushDialogue(ProgressDialogue(async_task, messagePrefix,
-                                                        create_sr_complete_callback,
-                                                        inOtherConfig))
+                                                        inOtherConfig,
+                                                        OnComplete=create_sr_complete_callback))
 
         except Exception as e:
             Layout.Inst().PushDialogue(InfoDialogue(Lang("Storage Repository Creation Failed"), Lang(e)))


### PR DESCRIPTION
In the previous PR, in the `__init__`of `ProgressDialogue`, I put the keywork arguments after the positional arguments. But I forgot to do the same in `CommitCreate` when we construct a `ProgressDialogue`

Test the OnComplete callback was called:
```
Jun  7 01:07:47 xrtmia-11-05 xsconsole: stephen TaskEntry.Status: %s
Jun  7 01:07:47 xrtmia-11-05 xsconsole: True
Jun  7 01:07:47 xrtmia-11-05 xsconsole: SR.create complete and call back is called
Jun  7 01:07:47 xrtmia-11-05 xsconsole: {'opaqueRef': 'OpaqueRef:752a9389-edae-1b43-d96a-1fa24166d44a', 'type': 'any', 'hash': 6275920129978874783}
```
