### PR TITLE
CA-388527: Keep python2 and python3 compatibility

### DIFF
--- a/XSConsoleDialogueBases.py
+++ b/XSConsoleDialogueBases.py
@@ -634,13 +634,13 @@ class SRDialogue(Dialogue):
         self.DoAction(self.choices[inChoice].sr)
 
 class ProgressDialogue(Dialogue):
-    def __init__(self, inTask, inText, *args, OnComplete=None):
+    def __init__(self, inTask, inText, *args, **kwargs):
         Dialogue.__init__(self)
         self.task = inTask
         self.text = inText
         # OnComplete is a function to call when the task completes
         # Used for getting task result and do something after the task completes
-        self.OnComplete = OnComplete
+        self.OnComplete = kwargs.get('OnComplete', None)
         self.args = args # Arguments to pass to OnComplete
 
         self.ChangeState('INITIAL')


### PR DESCRIPTION
The PR https://github.com/xapi-project/xsconsole/pull/42 uses keyword-only argument which is not supported in Python2 (led to build errors, although the Python file worked on XS8) . In XS8, we still uses python2, so fix this to work both in python2 and python3

Build success in XS8:
```
INFO: Done(/tmp/kojienv.crBpR8EVY/scratch/xsconsole-11.0.5-1.1.g52be83b.xs8.src.rpm) Config(pb-stephenche-x8) 0 minutes 5 seconds
INFO: Results and/or logs in: /home/stephenche/xs9/xsconsole.spec/SRPM//build
Finish: run
```
Build success in XS9:
```
INFO: Done(/tmp/kojienv.ZZrHfUNdW/scratch/xsconsole-11.0.5-1.1.g52be83b.xs9.src.rpm) Config(pb-stephenche-x9) 0 minutes 4 seconds
INFO: Results and/or logs in: /home/stephenche/xs9/xsconsole.spec/SRPM//build
Finish: run
```
