### PR TITLE
CA-390512: Improved xenapi error handling

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -209,8 +209,7 @@ class Data:
                     # NULL or dangling reference
                     self.data['host']['crash_dump_sr'] = None
 
-                convertCPU = lambda cpu: self.session.xenapi.host_cpu.get_record(cpu)
-                self.data['host']['host_CPUs'] = list(map(convertCPU, self.data['host']['host_CPUs']))
+                self.UpdateHostCPUs()
 
                 def convertPIF(inPIF):
                     retVal = self.session.xenapi.PIF.get_record(inPIF)
@@ -359,6 +358,17 @@ class Data:
         self.ScanService('chronyd')
 
         self.DeriveData()
+
+    def UpdateHostCPUs(self):
+        convertCPU = lambda cpu: self.session.xenapi.host_cpu.get_record(cpu)
+        hostCPUs = list(map(convertCPU, self.data['host']['host_CPUs']))
+
+        self.data['host']['host_CPUs'] = []
+        for cpu in hostCPUs:
+            if 'HANDLE_INVALID' in cpu:
+                XSLogError('xenapi host_cpu: ' + ', '.join(cpu))
+            else:
+                self.data['host']['host_CPUs'].append(cpu)
 
     def DeriveData(self):
         self.data.update({


### PR DESCRIPTION
In some cases we may fail to query the host CPUs due to an invalid reference, in this case we should log the failure and not add it into the list of host CPUs.
In the event of a failure we receive a list of the form: `['HANDLE_INVALID', 'host_cpu', '<uuid>']`
In a success we receive a dictionary which is later used to populate the number of CPUs per name but does not check that the contents of host_CPUs is a list of dictionaries.