### PR TITLE
CA-395025: Local command shell login failed on XS9

### DIFF
--- a/XSConsoleAuth.py
+++ b/XSConsoleAuth.py
@@ -113,7 +113,7 @@ class Auth:
                 session.close()
 
     def PAMAuthenticate(self, inUsername, inPassword):
-        if not pam.authenticate(inUsername, inPassword, service="passwd"):
+        if not pam.authenticate(inUsername, inPassword, service="password-auth"):
             # Display a generic message for all failures
             raise Exception(Lang("The system could not log you in.  Please check your access credentials and try again."))
 


### PR DESCRIPTION
Pam passwd service is updated to handle updating password only Here before offer local shell, we want to authenticate username and password, thus password-auth pam service should be used

This fix is compatible with XS8 and XS9