### PR TITLE
When no interfaces are found, clarify this does not mean there are no interfaces at all

### DIFF
--- a/plugins-base/XSFeatureInterface.py
+++ b/plugins-base/XSFeatureInterface.py
@@ -47,7 +47,7 @@ class InterfaceDialogue(Dialogue):
 
         if len(choiceDefs) == 0:
             XSLog('Configure Management Interface found no PIFs to present')
-            choiceDefs.append(ChoiceDef(Lang("<No interfaces present>"), None))
+            choiceDefs.append(ChoiceDef(Lang("<Couldn't retrieve data about existing interfaces>"), None))
         else:
             choiceDefs.append(ChoiceDef(Lang("Disable Management Interface"), lambda: self.HandleNICChoice(None)))
 


### PR DESCRIPTION
The supporter host could just be having trouble connecting to the coordinator.