### PR TITLE
CP-54331 Enable XSConsole to Set Auto mode

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -1099,6 +1099,16 @@ class Data:
         self.RequireSession()
         self.session.xenapi.host.disable_ssh(self.host.opaqueref())
 
+    def GetSSHAutoMode(self):
+        Auth.Inst().AssertAuthenticatedOrPasswordUnset()
+        self.RequireSession()
+        return self.session.xenapi.host.get_ssh_auto_mode(self.host.opaqueref())
+
+    def SetSSHAutoMode(self, inMode):
+        Auth.Inst().AssertAuthenticatedOrPasswordUnset()
+        self.RequireSession()
+        self.session.xenapi.host.set_ssh_auto_mode(self.host.opaqueref(), inMode)
+
     def Ping(self,  inDest):
         # Must be careful that no unsanitised data is passed to the command
         if not re.match(r'[0-9a-zA-Z][-0-9a-zA-Z.]*$',  inDest):

--- a/plugins-base/XSFeatureAutoMode.py
+++ b/plugins-base/XSFeatureAutoMode.py
@@ -1,0 +1,117 @@
+# Copyright (c) Cloud Software Group, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 only.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+if __name__ == "__main__":
+    raise Exception("This script is a plugin for xsconsole and cannot run independently")
+
+from XSConsoleStandard import *
+
+class AutoModeDialogue(Dialogue):
+    def __init__(self):
+        Dialogue.__init__(self)
+        pane = self.NewPane(DialoguePane(self.parent))
+        pane.TitleSet(Lang("Configure SSH Auto Mode"))
+        pane.AddBox()
+
+        self.autoModeMenu = Menu(self, None, Lang("Configure SSH Auto Mode"), [
+            ChoiceDef(Lang("Enable Auto Mode"), lambda: self.HandleChoice(True)),
+            ChoiceDef(Lang("Disable Auto Mode"), lambda: self.HandleChoice(False))
+            ])
+
+        self.UpdateFields()
+
+    def UpdateFields(self):
+        pane = self.Pane()
+        pane.ResetFields()
+
+        pane.AddTitleField(Lang("Please select an option"))
+        pane.AddMenuField(self.autoModeMenu)
+        pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
+
+    def HandleKey(self, inKey):
+        handled = self.autoModeMenu.HandleKey(inKey)
+
+        if not handled and inKey == 'KEY_ESCAPE':
+            Layout.Inst().PopDialogue()
+            handled = True
+
+        return handled
+
+    def HandleChoice(self, inChoice):
+        data = Data.Inst()
+        Layout.Inst().PopDialogue()
+
+        try:
+            if inChoice:
+                data.SetSSHAutoMode(True)
+                message = Lang("SSH Auto Mode Enabled")
+            else:
+                data.SetSSHAutoMode(False)
+                message = Lang("SSH Auto Mode Disabled")
+
+            Layout.Inst().PushDialogue(InfoDialogue(message))
+
+        except Exception as e:
+            Layout.Inst().PushDialogue(InfoDialogue(Lang("Failed: ")+Lang(e)))
+
+        data.Update()
+
+
+class XSFeatureAutoMode:
+    @classmethod
+    def StatusUpdateHandler(cls, inPane):
+        data = Data.Inst()
+        inPane.AddTitleField(Lang("SSH Auto Mode"))
+
+        try:
+            autoModeStatus = False
+            if Auth.Inst().IsAuthenticated():
+                autoModeStatus = data.GetSSHAutoMode()
+            
+            if autoModeStatus:
+                message = Lang('enabled. To disable')
+            else:
+                message = Lang('disabled. To enable')
+
+            inPane.AddWrappedTextField(Lang(
+                "SSH Auto Mode allows the system to automatically enable or disable SSH based on XAPI conditions. "
+                "Currently SSH Auto Mode is ") + message + Lang(" this feature, press <Enter>."))
+        except Exception as e:
+            inPane.AddWrappedTextField(Lang(
+                "SSH Auto Mode information is not available. Please log in to access this feature."))
+
+        inPane.AddKeyHelpField( {
+            Lang("<Enter>") : Lang("Configure SSH Auto Mode")
+        } )
+
+    @classmethod
+    def ActivateHandler(cls):
+        DialogueUtils.AuthenticatedOnly(lambda: Layout.Inst().PushDialogue(AutoModeDialogue()))
+
+    def Register(self):
+        Importer.RegisterNamedPlugIn(
+            self,
+            'SSH_AUTO_MODE', # Key of this plugin for replacement, etc.
+            {
+                'menuname' : 'MENU_REMOTE',
+                'menupriority' : 110,
+                'menutext' : Lang('Configure SSH Auto Mode'),
+                'statusupdatehandler' : self.StatusUpdateHandler,
+                'activatehandler' : self.ActivateHandler
+            }
+        )
+
+# Register this plugin when module is imported
+XSFeatureAutoMode().Register() 


### PR DESCRIPTION
This PR adds a new feature module that allows users to configure SSH Auto Mode. This functionality enables the system to automatically enable or disable SSH service based on XAPI conditions, improving system flexibility and security.


- Created new plugin `XSFeatureAutoMode.py` with UI for enabling/disabling auto mode
- Added status display showing current auto mode configuration
- Implemented proper authentication and error handling

![automode3](https://github.com/user-attachments/assets/26073cda-b4fb-4848-8d8e-917de1a90c90)
![automode1](https://github.com/user-attachments/assets/1786ed0c-63ee-40e8-8ff6-97a72f293539)


(note: This PR should merged after the change for XAPI is done)