### PR TITLE
CP-54442: Update for network devices not being renamed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ env:
 jobs:
   python-checks:
     name: minimaltest (pre-commit)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          #: Install Python 2.7 from Ubuntu 20.04 using apt-get install
+          #: Install Python 2.7 from Ubuntu 22.04 using apt-get install
           sudo apt-get update && sudo apt-get install -y python2
           curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
           python2 get-pip.py


### PR DESCRIPTION
A new proposed change in networkd will replace the interface-rename functionality to order the network devices. The result of the ordering performed by interface-rename is to rename the devices like eth0, eth1, etc. The new change in networkd will not rename the devices any more. Consequently, the use of hard-coded eth<N> in network reset in xsconsole should be eliminated to cope with the new change.

Additionally, the new networkd replacing the interface rename functionality will perform the network reset with xapi together.

The interface rename functionality will be deprecated in the future.