### PR TITLE
CA-413431: filter OpaqueRef:NULL case

### DIFF
--- a/plugins-base/XSFeatureDMV.py
+++ b/plugins-base/XSFeatureDMV.py
@@ -56,6 +56,8 @@ class DMVUtils:
         variantRef = driver.selected_variant(None)
         if variantRef is None:
             return None
+        if variantRef.OpaqueRef() == "OpaqueRef:NULL":
+            return None
         variant = Task.Sync(lambda x: x.xenapi.Driver_variant.get_record(variantRef.OpaqueRef()))
         return variant['uuid']
 


### PR DESCRIPTION
  exception, if one driver has no selected variant, and we want to
  select a variant for this driver

  we cannot pass OpaqueRef:NULL to XenAPI get_record function