### PR TITLE
CA-415864: MANAGEMENT_INTERFACE is not cleared in network reset

### DIFF
--- a/plugins-base/XSFeatureNetworkReset.py
+++ b/plugins-base/XSFeatureNetworkReset.py
@@ -19,7 +19,6 @@ if __name__ == "__main__":
 from XSConsoleStandard import *
 
 pool_conf = '%s/pool.conf' % (Config.Inst().XCPConfigDir())
-interface_reconfigure = '%s/interface-reconfigure' % (Config.Inst().LibexecPath())
 inventory_file = '/etc/xensource-inventory'
 management_conf = '/etc/firstboot.d/data/management.conf'
 network_reset = '/var/tmp/network-reset'
@@ -358,17 +357,9 @@ class NetworkResetDialogue(Dialogue):
 		os.system('service xapi stop >/dev/null 2>/dev/null')
 
 		# Reconfigure new management interface
-		if os.access('/tmp/do-not-use-networkd', os.F_OK):
-			if_args = ' --force ' + bridge + ' rewrite --mac=x --device=' + self.device + ' --mode=' + self.mode
-			if self.mode == 'static':
-				if_args += ' --ip=' + self.IP + ' --netmask=' + self.netmask
-				if self.gateway != '':
-					if_args += ' --gateway=' + self.gateway
-			os.system(interface_reconfigure + if_args + ' >/dev/null 2>/dev/null')
-		else:
-			os.system('service xcp-networkd stop >/dev/null 2>/dev/null')
-			try: os.remove('/var/xapi/networkd.db')
-			except: pass
+		os.system('service xcp-networkd stop >/dev/null 2>/dev/null')
+		try: os.remove('/var/xapi/networkd.db')
+		except: pass
 
 		inventory = read_inventory()
 		if renamed:

--- a/plugins-base/XSFeatureNetworkReset.py
+++ b/plugins-base/XSFeatureNetworkReset.py
@@ -370,16 +370,19 @@ class NetworkResetDialogue(Dialogue):
 			try: os.remove('/var/xapi/networkd.db')
 			except: pass
 
+		inventory = read_inventory()
 		if renamed:
 			# Update interfaces in inventory file
-			inventory = read_inventory()
 			if self.vlan:
 				inventory['MANAGEMENT_INTERFACE'] = 'xentemp'
 			else:
 				inventory['MANAGEMENT_INTERFACE'] = bridge
-			inventory['CURRENT_INTERFACES'] = ''
-			write_inventory(inventory)
-		# Else, networkd will update the inventory file.
+		else:
+			# networkd will determine the bridge name and update to inventory file.
+			inventory['MANAGEMENT_INTERFACE'] = ''
+
+		inventory['CURRENT_INTERFACES'] = ''
+		write_inventory(inventory)
 
 		# Rewrite firstboot management.conf file, which will be picked it by xcp-networkd on restart (if used)
 		f = open(management_conf, 'w')


### PR DESCRIPTION
The issue is the "MANAGEMENT_INTERFACE" in /etc/xensource-inventory is not cleared in a networking reset. While the networkd is still trying to read the value of "MANAGEMENT_INTERFACE" as the bridge name. This caused the new network interface was added into the bridge before reset.