### PR TITLE
Add python 3.12 support and drop 2.7

### DIFF
--- a/XSConsoleImporter.py
+++ b/XSConsoleImporter.py
@@ -15,7 +15,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import imp, os, re, sys, traceback
+import importlib.util, os, re, sys, traceback
 
 from XSConsoleLog import *
 from XSConsoleMenus import *
@@ -46,8 +46,10 @@ class Importer:
                         try:
                             try:
                                 # Import using variable as module name
-                                (fileObj, pathName, description) = imp.find_module(importName, [root])
-                                imp.load_module(importName, fileObj, pathName, description)
+                                spec = importlib.util.spec_from_file_location(
+                                    importName, os.path.join(root, filename))
+                                module = importlib.util.module_from_spec(spec)
+                                spec.loader.exec_module(module)
                             except Exception as e:
                                 try: XSLogError(*traceback.format_tb(sys.exc_info()[2]))
                                 except: pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "XSConsole"
 dynamic = ["version"]
 description = "Xenserver Status Report"
-requires-python = "2.7"
+requires-python = ">=2.7, <3.12"
 license = "GPL-2.0-or-later"
 keywords = ["xenserver", "xen-project"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ readme = "README.md"
 classifiers = [
     "Environment :: Console",
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2) or later",
     "Operating System :: POSIX :: Linux :: XenServer/XCP-ng Dom0",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "XSConsole"
 dynamic = ["version"]
 description = "Xenserver Status Report"
-requires-python = ">=2.7, <3.12"
+requires-python = ">=3.6"
 license = "GPL-2.0-or-later"
 keywords = ["xenserver", "xen-project"]
 authors = [
@@ -20,13 +20,13 @@ classifiers = [
     "Environment :: Console",
     "Development Status :: 5 - Production/Stable",
     "Operating System :: POSIX :: Linux :: XenServer/XCP-ng Dom0",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: System :: Logging",
     "Topic :: System :: Monitoring",


### PR DESCRIPTION
This switches away from deprecated `imp`, and breaks support for python 2.7, but I expect this branch to really support only python3 now, so we likely don't care about adding backward compatibility here.

Builds on #72 