### PR TITLE
CA-417641 Update ntp-dhcp server file path

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -602,8 +602,8 @@ class Data:
         for interface in interfaces:
             ntpServer = self.GetDHCPNTPServer(interface)
 
-            with open("/var/lib/dhclient/chrony.servers.%s" % interface, "w") as chronyFile:
-                chronyFile.write("%s iburst prefer\n" % ntpServer)
+            with open("/run/chrony-dhcp/%s.sources" % interface, "w") as chronyFile:
+                chronyFile.write("server %s iburst prefer\n" % ntpServer)
 
         # Ensure chrony is enabled
         self.EnableService("chronyd")
@@ -655,7 +655,7 @@ class Data:
         newPermissions = oldPermissions & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         os.chmod("/etc/dhcp/dhclient.d/chrony.sh", newPermissions)
 
-        getstatusoutput("rm -f /var/lib/dhclient/chrony.servers.*")
+        getstatusoutput("rm -f /run/chrony-dhcp/*.sources")
 
     def SetTimeManually(self, date):
         # Double-check authentication


### PR DESCRIPTION
xsconsole can set ntp to `Use DHCP NTP Servers` or `Use Default NTP Servers`, `Provide NTP Servers Manually`. This is so-called `dhcp` `defaul`t and `manual` mode.

When switching from other modes to DHCP, the DHCP-provided NTP servers should be added to the Chrony sources. Conversely, they should be removed when switching away from DHCP.

In XS9, the ntp-dhcp server path is outdated as the chrony version update, comparing to XS8.
xs8-chrony: version 3.2, the server file with dhclient is `/var/lib/dhclient/chrony.servers.$interface`
xs9-chrony: version 4.6.1, the server file with dhclient is `/run/chrony-dhcp/$interface.sources`

It takes effect by write `server $source iburst prefer` to `/run/chrony-dhcp/$interface.sources` and `/run/chrony-dhcp` is sourcedir in `/etc/chrony.conf`.