### PR TITLE
Order Remote Service menu items consistently

### DIFF
--- a/plugins-base/XSFeatureRemoteShell.py
+++ b/plugins-base/XSFeatureRemoteShell.py
@@ -164,7 +164,7 @@ class XSFeatureRemoteShell:
             'REMOTE_SHELL', # Key of this plugin for replacement, etc.
             {
                 'menuname' : 'MENU_REMOTE',
-                'menupriority' : 100,
+                'menupriority' : 50,
                 'menutext' : Lang('Enable/Disable/Auto Remote Shell') ,
                 'statusupdatehandler' : self.StatusUpdateHandler,
                 'activatehandler' : self.ActivateHandler


### PR DESCRIPTION
The priorities of the Remote Service Configuration menu items are all the same which means the order is not stable - it depends on the order the OS returned the plugin file names during import.

Arbitrarily set the priority so that it is consistent:

Enable/Disable/Auto Remote Shell
Remote Logging (syslog)