### PR TITLE
CA-421635 Show the real NTP servers in dhcp NTP mode

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -672,6 +672,19 @@ class Data:
         getstatusoutput("date --set='%s'" % timestring)
         getstatusoutput("hwclock --utc --systohc")
 
+    def GetNTPServersFromChronyc(self):
+        servers =[]
+        (status, output) = getstatusoutput("chronyc -c sources")
+        # output is csv format: ^,*,10.79.16.11,5,7,377,13,-0.000067081,-0.000084192,0.172569677
+        if status == 0:
+            for line in output.split("\n"):
+                fields = line.split(",")
+                if len(fields) >= 3:
+                    server = fields[2].strip()
+                    if server != "":
+                        servers.append(server)
+        return servers
+
     def SaveToResolveConf(self):
         # Double-check authentication
         Auth.Inst().AssertAuthenticated()

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -428,11 +428,7 @@ class XSFeatureNTP:
 
             servers = data.ntp.servers([])
             if ntpMethod == "DHCP":
-                gateway = data.ManagementGateway()
-                if gateway is None:
-                    gateway = "Refreshing..."
-
-                servers = [Lang(str(gateway) + " (DHCP)")]
+                servers = data.GetNTPServersFromChronyc()
 
             inPane.NewLine()
 


### PR DESCRIPTION
Currently, xsconsole shows Gateway but not NTP server. This is not consistent with the description "Currently NTP is enabled, and the following servers are configured."
Get the servers form `chronyc -c sources`.