### PR TITLE
CP-308543 Use xenapi to manage timezone and NTP

### DIFF
--- a/XSConsoleConstants.py
+++ b/XSConsoleConstants.py
@@ -1,7 +1,8 @@
 # Default NTP domains are <int>.[centos|xenserver].pool.ntp.org
 CENTOS_NTP_POOL_DOMAIN = "centos.pool.ntp.org"
-DEFAULT_NTP_DOMAINS = [CENTOS_NTP_POOL_DOMAIN, "xenserver.pool.ntp.org"]
+XENSERVER_NTP_POOL_DOMAIN = "xenserver.pool.ntp.org"
+DEFAULT_NTP_DOMAINS = [CENTOS_NTP_POOL_DOMAIN, XENSERVER_NTP_POOL_DOMAIN]
 
 NUM_DEFAULT_NTP_SERVERS = 4
 
-DEFAULT_NTP_SERVERS = ["%d.%s" % (i, CENTOS_NTP_POOL_DOMAIN) for i in range(NUM_DEFAULT_NTP_SERVERS)]
+DEFAULT_NTP_SERVERS = ["%d.%s" % (i, XENSERVER_NTP_POOL_DOMAIN) for i in range(NUM_DEFAULT_NTP_SERVERS)]

--- a/plugins-base/XSFeatureNTP.py
+++ b/plugins-base/XSFeatureNTP.py
@@ -100,7 +100,6 @@ class NTPDialogue(Dialogue):
         The options are:
         - Add New Server
         - Remove Server (only shown if servers are already configured)
-        - Remove All Servers (only shown if servers are already configured)
         """
         choiceDefs = [
             ChoiceDef(Lang("Add New Server"), lambda: self.HandleManualChoice("ADD"))
@@ -114,12 +113,6 @@ class NTPDialogue(Dialogue):
             choiceDefs.append(
                 ChoiceDef(
                     Lang("Remove Server"), lambda: self.HandleManualChoice("REMOVE")
-                )
-            )
-            choiceDefs.append(
-                ChoiceDef(
-                    Lang("Remove All Servers"),
-                    lambda: self.HandleManualChoice("REMOVEALL"),
                 )
             )
 
@@ -255,7 +248,7 @@ class NTPDialogue(Dialogue):
         Handle the user's choice of within the manual NTP configuration method.
 
         param: inChoice: The user's choice of NTP configuration method.
-        inChoice is one of "ADD", "REMOVE", or "REMOVEALL".
+        inChoice is one of "ADD", "REMOVE".
         """
         data = Data.Inst()
         try:
@@ -263,11 +256,6 @@ class NTPDialogue(Dialogue):
                 self.ChangeState("ADD")
             elif inChoice == "REMOVE":
                 self.ChangeState("REMOVE")
-            elif inChoice == "REMOVEALL":
-                Layout.Inst().PopDialogue()
-                Layout.Inst().TransientBanner(Lang("Removing All NTP Servers..."))
-                data.NTPServersSet([])
-                self.Commit(Lang("All server entries deleted"), "MANUAL")
 
         except Exception as e:
             Layout.Inst().PushDialogue(InfoDialogue( Lang("Operation Failed"), Lang(e)))


### PR DESCRIPTION
xenapi host.set_timezone to config the timezone of the host.
host.set_ntp_mode to manage the NTP. The NTP mode mapping to xsconsole is:
DHCP - dhcp
Factory - default
Custom - manual
Disabled - none
host.set_ntp_custom_servers to configure the NTP servers that used in Custom mode.