### PR TITLE
CA-417645 Refine Remote Shell status in xsconsole

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -366,6 +366,7 @@ class Data:
         self.UpdateFromKeymap()
 
         self.data['chkconfig'] = {}
+        self.data['service_active'] = {}
         self.ScanService('sshd')
         self.ScanService('chronyd')
 
@@ -767,6 +768,9 @@ class Data:
     def ScanService(self, service):
         (status, output) = getstatusoutput("systemctl is-enabled %s" % (service,))
         self.data['chkconfig'][service] = status == 0
+
+        (status, output) = getstatusoutput("systemctl is-active %s" % (service,))
+        self.data['service_active'][service] = status == 0
 
     def ScanResolvConf(self, inLines):
         self.data['dns'] = {

--- a/plugins-base/XSFeatureRemoteShell.py
+++ b/plugins-base/XSFeatureRemoteShell.py
@@ -68,7 +68,7 @@ class DisableOptionsDialogue(Dialogue):
                     "Command Shell to terminate them.")
             if inChoice == self.SSH_MODE_AUTO:
                 data.SetSSHAutoMode(True)
-                message = Lang("SSH auto-mode has been configured. For security,"
+                message = Lang("SSH auto-mode has been configured. For security, "
                         "SSH is normally disabled and will only be enabled in case of emergency.")
 
             Layout.Inst().PushDialogue(InfoDialogue(message))
@@ -139,16 +139,18 @@ class XSFeatureRemoteShell:
         data = Data.Inst()
         inPane.AddTitleField(Lang("Remote Shell (ssh)"))
 
-        if data.chkconfig.sshd() is None:
-            message = Lang('unknown.  To enable or disable')
-        elif data.chkconfig.sshd():
-            message = Lang('enabled.  To disable')
+        is_running = data.service_active.sshd()
+
+        if is_running is None:
+            message = Lang('unknown. To configure')
+        elif is_running:
+            message = Lang('running. To stop and disable')
         else:
-            message = Lang('disabled.  To enable')
+            message = Lang('stopped. To start and enable')
 
         inPane.AddWrappedTextField(Lang(
-            "This server can accept a remote login via ssh.  Currently remote login is ") +
-            message + Lang(" this feature, press <Enter>."))
+            "This server can accept a remote login via ssh.  Currently SSH service is ") +
+            message + Lang(" SSH service, press <Enter>."))
 
         inPane.AddKeyHelpField( {
             Lang("<Enter>") : Lang("Configure Remote Shell")


### PR DESCRIPTION
- Align XSConsole's SSH status display with XAPI's `ssh-enabled` logic. Previously, XSConsole showed the boot persistence status (enabled/disabled), leading to confusion with XAPI's configuration. The UI now displays the actual service state to correctly indicate if the server can accept SSH connections
- refine the message when enable auto_mode