### PR TITLE
XSFeatureInterface: Reset old management interface configuration when switching to a new one

### DIFF
--- a/plugins-base/XSFeatureInterface.py
+++ b/plugins-base/XSFeatureInterface.py
@@ -28,6 +28,7 @@ class InterfaceDialogue(Dialogue):
         self.nic=None
         self.converting = False
         currentPIF = None
+        self.oldPIF = None
         choiceArray = []
         for i in range(len(data.host.PIFs([]))):
             pif = data.host.PIFs([])[i]
@@ -45,6 +46,7 @@ class InterfaceDialogue(Dialogue):
 
             choiceDefs.append(ChoiceDef(choiceName, lambda: self.HandleNICChoice(self.nicMenu.ChoiceIndex())))
 
+        self.oldPIF = currentPIF
         if len(choiceDefs) == 0:
             XSLog('Configure Management Interface found no PIFs to present')
             choiceDefs.append(ChoiceDef(Lang("<Couldn't retrieve data about existing interfaces>"), None))
@@ -81,11 +83,14 @@ class InterfaceDialogue(Dialogue):
         self.netmask = '0.0.0.0'
         self.gateway = '0.0.0.0'
         self.hostname = data.host.hostname('')
+        self.oldIP = self.IP
 
         if currentPIF is not None:
             if 'ip_configuration_mode' in currentPIF: self.mode = currentPIF['ip_configuration_mode']
             if self.mode.lower().startswith('static'):
-                if 'IP' in currentPIF: self.IP = currentPIF['IP']
+                if 'IP' in currentPIF:
+                    self.IP = currentPIF['IP']
+                    self.oldIP = self.IP
                 if 'netmask' in currentPIF: self.netmask = currentPIF['netmask']
                 if 'gateway' in currentPIF: self.gateway = currentPIF['gateway']
 
@@ -445,6 +450,11 @@ class InterfaceDialogue(Dialogue):
             else:
                 data.HostnameSet(self.hostname)
             data.ReconfigureManagement(pif, self.mode, self.IP,  self.netmask, self.gateway, dns)
+
+            # Reset old PIF in order to prevent network conflicts
+            if self.oldPIF != pif and self.IP == self.oldIP:
+                data.ReconfigureManagement(self.oldPIF, 'static', self.oldIP,  '0.0.0.0', '0.0.0.0', '')
+
         data.Update()
         self.hostname = data.host.hostname('') # Hostname may have changed.  Must be after data.Update()
 


### PR DESCRIPTION
Fix the following issue from upstream:
https://github.com/xapi-project/xsconsole/issues/8

Essentially, reset the old management interface configuration when switching to a new one, in order to avoid network conflicts