### PR TITLE
Retry the xapi connection instead of latching it broken forever

### DIFF
--- a/XSConsoleAuth.py
+++ b/XSConsoleAuth.py
@@ -35,6 +35,11 @@ else:
 class Auth:
     instance = None
 
+    # Seconds to wait before retrying to connect to xapi after a connection
+    # timeout, so that a long-lived xsconsole recovers once xapi is responsive
+    # again, e.g. after an HA pool master failover.
+    CONNECTION_RETRY_SECONDS = 60
+
     def __init__(self):
         self.isAuthenticated = False
         self.loggedInUsername = ''
@@ -43,6 +48,7 @@ class Auth:
         self.testingHost = None
         self.authTimestampSeconds = None
         self.masterConnectionBroken = False
+        self.connectionBrokenTimestamp = None
         socket.setdefaulttimeout(15)
 
         self.testMode = False
@@ -107,8 +113,7 @@ class Auth:
                     session.logout()
                 except socket.timeout:
                     session = None
-                    self.masterConnectionBroken = True
-                    self.error = 'The master connection has timed out.'
+                    self.ConnectionTimedOut()
             finally:
                 session.close()
 
@@ -158,43 +163,59 @@ class Auth:
         self.isAuthenticated = False
         self.loggedInUsername = None
 
+    def ConnectionTimedOut(self):
+        self.masterConnectionBroken = True
+        self.connectionBrokenTimestamp = getTimeStamp()
+        self.error = 'The master connection has timed out.'
+        XSLog('XenAPI connection timed out - retrying in ' + str(self.CONNECTION_RETRY_SECONDS) + ' seconds at most')
+
     def OpenSession(self):
         session = None
 
-        if not self.masterConnectionBroken:
-            try:
-                # Try the local Unix domain socket first
-                session = XenAPI.xapi_local()
-                if not session is None:
-                    session.login_with_password('root','','','XSConsole')
-                    if session._session is None:
-                        session = None
-            except socket.timeout:
-                session = None
-                self.masterConnectionBroken = True
-                self.error = 'The master connection has timed out.'
-            except Exception as e:
-                session = None
-                # pylint: disable-next=redefined-variable-type  # ToString may handle it
-                self.error = e
+        if self.masterConnectionBroken:
+            if getTimeStamp() - self.connectionBrokenTimestamp < self.CONNECTION_RETRY_SECONDS:
+                # Don't hammer an unresponsive xapi with blocking connection attempts
+                return None
+            # Restart the cooldown before retrying, so a failure of any kind below
+            # doesn't lead to a retry on every call
+            self.connectionBrokenTimestamp = getTimeStamp()
 
-            if session is None and self.testingHost is not None:
-                # Local session couldn't connect, so try remote.
-                session = XenAPI.Session("https://"+self.testingHost)
-                try:
-                    session.login_with_password('root', self.defaultPassword,'','XSConsole')
-
-                except XenAPI.Failure as e:
-                    if e.details[0] != 'HOST_IS_SLAVE': # Ignore slave errors when testing
-                        session = None
-                        self.error = e
-                except socket.timeout:
+        try:
+            # Try the local Unix domain socket first
+            session = XenAPI.xapi_local()
+            if not session is None:
+                session.login_with_password('root', '', '', 'XSConsole')
+                if session._session is None:
                     session = None
-                    self.masterConnectionBroken = True
-                    self.error = 'The master connection has timed out.'
-                except Exception as e:
+        except socket.timeout:
+            session = None
+            self.ConnectionTimedOut()
+        except Exception as e:
+            session = None
+            # pylint: disable-next=redefined-variable-type  # ToString may handle it
+            self.error = e
+
+        if session is None and self.testingHost is not None:
+            # Local session couldn't connect, so try remote.
+            session = XenAPI.Session("https://" + self.testingHost)
+            try:
+                session.login_with_password('root', self.defaultPassword, '', 'XSConsole')
+
+            except XenAPI.Failure as e:
+                if e.details[0] != 'HOST_IS_SLAVE':  # Ignore slave errors when testing
                     session = None
                     self.error = e
+            except socket.timeout:
+                session = None
+                self.ConnectionTimedOut()
+            except Exception as e:
+                session = None
+                self.error = e
+
+        if session is not None and self.masterConnectionBroken:
+            XSLog('XenAPI connection recovered')
+            self.masterConnectionBroken = False
+
         return session
 
     def NewSession(self):


### PR DESCRIPTION

Fixes #89

`Auth` sets `masterConnectionBroken` when a XenAPI call times out, and `OpenSession()` never attempts another connection once the flag is set — the flag is never reset anywhere. A long-lived xsconsole (e.g. the one on the physical console) that experiences a single 15-second xapi hang therefore never talks to xapi again and shows `Pool master is unreachable.` forever, while newly launched instances work fine. Easy to hit during an HA pool-master failover, which is how it was reported: https://xcp-ng.org/forum/post/106689

This keeps the flag but as a cooldown rather than a latch:

* after a `socket.timeout`, connection attempts are skipped for `CONNECTION_RETRY_SECONDS` (60s), so an unresponsive xapi doesn't block the UI for the socket timeout on every update cycle — the behaviour the latch presumably existed to prevent;
* once the cooldown expires the next `OpenSession()` call tries again;
* a successful login clears the flag;
* the transitions are logged (`XenAPI connection timed out - retrying in 60 seconds at most` / `XenAPI connection recovered`), where previously the process went silent with no trace.

The timeout handling is factored into `Auth.ConnectionTimedOut()`, also used by the test-mode `TCPAuthenticate()` path so the retry timestamp is always set alongside the flag.

## Validation

On XCP-ng 8.3: `kill -STOP $(pgrep -x xapi)`, press F5 twice on the console xsconsole, `kill -CONT` after 60s.

Before (current master): the console is stuck on `Pool master is unreachable.` forever; only restarting xsconsole recovers it.

After (this branch, from the host's syslog):

```
17:44:58 xsconsole: XenAPI connection timed out - retrying in 60 seconds at most
17:45:24 bugtest: xapi unfrozen
17:45:59 xsconsole: XenAPI connection recovered
```

…and the console repopulates with live data on the next refresh, no restart needed.
